### PR TITLE
Fix get zone response

### DIFF
--- a/src/main/java/io/vinyldns/java/VinylDNSClient.java
+++ b/src/main/java/io/vinyldns/java/VinylDNSClient.java
@@ -22,10 +22,7 @@ import io.vinyldns.java.model.record.set.DeleteRecordSetRequest;
 import io.vinyldns.java.model.record.set.ListRecordSetsRequest;
 import io.vinyldns.java.model.record.set.ListRecordSetsResponse;
 import io.vinyldns.java.model.record.set.RecordSetChange;
-import io.vinyldns.java.model.zone.GetZoneRequest;
-import io.vinyldns.java.model.zone.ListZonesRequest;
-import io.vinyldns.java.model.zone.ListZonesResponse;
-import io.vinyldns.java.model.zone.Zone;
+import io.vinyldns.java.model.zone.*;
 import io.vinyldns.java.responses.VinylDNSFailureResponse;
 import io.vinyldns.java.responses.VinylDNSResponse;
 import io.vinyldns.java.responses.VinylDNSSuccessResponse;
@@ -56,7 +53,7 @@ public interface VinylDNSClient {
    *     case of success and {@link VinylDNSFailureResponse
    *     VinylDNSFailureResponse&lt;ListZonesResponse&gt;} in case of failure
    */
-  VinylDNSResponse<Zone> getZone(GetZoneRequest request);
+  VinylDNSResponse<GetZoneResponse> getZone(GetZoneRequest request);
 
   // RecordSet
   /**

--- a/src/main/java/io/vinyldns/java/VinylDNSClientImpl.java
+++ b/src/main/java/io/vinyldns/java/VinylDNSClientImpl.java
@@ -32,10 +32,7 @@ import io.vinyldns.java.model.record.set.DeleteRecordSetRequest;
 import io.vinyldns.java.model.record.set.ListRecordSetsRequest;
 import io.vinyldns.java.model.record.set.ListRecordSetsResponse;
 import io.vinyldns.java.model.record.set.RecordSetChange;
-import io.vinyldns.java.model.zone.GetZoneRequest;
-import io.vinyldns.java.model.zone.ListZonesRequest;
-import io.vinyldns.java.model.zone.ListZonesResponse;
-import io.vinyldns.java.model.zone.Zone;
+import io.vinyldns.java.model.zone.*;
 import io.vinyldns.java.responses.VinylDNSFailureResponse;
 import io.vinyldns.java.responses.VinylDNSResponse;
 import io.vinyldns.java.responses.VinylDNSSuccessResponse;
@@ -77,10 +74,10 @@ public class VinylDNSClientImpl implements VinylDNSClient {
   }
 
   @Override
-  public VinylDNSResponse<Zone> getZone(GetZoneRequest request) {
+  public VinylDNSResponse<GetZoneResponse> getZone(GetZoneRequest request) {
     String path = "zones/" + request.getZoneId();
     return executeRequest(
-        new VinylDNSRequest<>(Methods.GET.name(), getBaseUrl(), path, request), Zone.class);
+        new VinylDNSRequest<>(Methods.GET.name(), getBaseUrl(), path, null), GetZoneResponse.class);
   }
 
   // RecordSet

--- a/src/main/java/io/vinyldns/java/model/zone/GetZoneResponse.java
+++ b/src/main/java/io/vinyldns/java/model/zone/GetZoneResponse.java
@@ -1,0 +1,32 @@
+package io.vinyldns.java.model.zone;
+
+public class GetZoneResponse {
+    private final Zone zone;
+
+    public GetZoneResponse(Zone zone) {
+        this.zone = zone;
+    }
+
+    public Zone getZone() {
+        return zone;
+    }
+
+    @Override
+    public String toString() {
+        return zone.toString();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        GetZoneResponse that = (GetZoneResponse) o;
+        return zone.equals(that.zone);
+    }
+
+    @Override
+    public int hashCode() {
+        return zone.hashCode();
+    }
+}

--- a/src/test/java/io/vinyldns/java/VinylDNSClientTest.java
+++ b/src/test/java/io/vinyldns/java/VinylDNSClientTest.java
@@ -120,7 +120,7 @@ public class VinylDNSClientTest {
 
   @Test
   public void getZoneSuccess() {
-    String response = client.gson.toJson(testZone1);
+    String response = client.gson.toJson(new GetZoneResponse(testZone1));
 
     wireMockServer.stubFor(
         get(urlEqualTo("/zones/" + testZone1.getId()))
@@ -130,11 +130,11 @@ public class VinylDNSClientTest {
                     .withHeader("Content-Type", "application/json")
                     .withBody(response)));
 
-    VinylDNSResponse<Zone> vinylDNSResponse = client.getZone(new GetZoneRequest(testZone1.getId()));
+    VinylDNSResponse<GetZoneResponse> vinylDNSResponse = client.getZone(new GetZoneRequest(testZone1.getId()));
 
     assertTrue(vinylDNSResponse instanceof ResponseMarker.Success);
     assertEquals(vinylDNSResponse.getStatusCode(), 200);
-    assertEquals(vinylDNSResponse.getValue(), testZone1);
+    assertEquals(vinylDNSResponse.getValue().getZone(), testZone1);
   }
 
   @Test
@@ -143,7 +143,7 @@ public class VinylDNSClientTest {
         get(urlEqualTo("/zones/" + zoneId))
             .willReturn(aResponse().withStatus(404).withBody("not found")));
 
-    VinylDNSResponse<Zone> vinylDNSResponse = client.getZone(new GetZoneRequest(zoneId));
+    VinylDNSResponse<GetZoneResponse> vinylDNSResponse = client.getZone(new GetZoneRequest(zoneId));
 
     assertTrue(vinylDNSResponse instanceof ResponseMarker.Failure);
     assertEquals(vinylDNSResponse.getStatusCode(), 404);


### PR DESCRIPTION
Addendum to #7. `getZone` response wasn't being properly deserialized and incorrect `payload` was being sent in request.

Changes:
- Removed `payload` from request
- Added `GetZoneResponse` wrapper for `Zone` to handle gson deserialization