### PR TITLE
Implement create group

### DIFF
--- a/src/main/java/io/vinyldns/java/VinylDNSClient.java
+++ b/src/main/java/io/vinyldns/java/VinylDNSClient.java
@@ -17,6 +17,8 @@ import io.vinyldns.java.model.batch.BatchResponse;
 import io.vinyldns.java.model.batch.CreateBatchRequest;
 import io.vinyldns.java.model.batch.ListBatchChangesRequest;
 import io.vinyldns.java.model.batch.ListBatchChangesResponse;
+import io.vinyldns.java.model.membership.CreateGroupRequest;
+import io.vinyldns.java.model.membership.Group;
 import io.vinyldns.java.model.membership.ListGroupsRequest;
 import io.vinyldns.java.model.membership.ListGroupsResponse;
 import io.vinyldns.java.model.record.set.CreateRecordSetRequest;
@@ -93,6 +95,15 @@ public interface VinylDNSClient {
   // ToDo: Get RecordSet Change
 
   // Groups
+  /**
+   * Create a group.
+   *
+   * @param request See {@link CreateGroupRequest CreateGroupRequest Model}
+   * @return {@link VinylDNSSuccessResponse VinylDNSSuccessResponse&lt;Group&gt;} in case
+   *     of success and {@link VinylDNSFailureResponse VinylDNSFailureResponse&lt;Group&gt;} in case
+   *     of failure.
+   */
+  VinylDNSResponse<Group> createGroup(CreateGroupRequest request);
 
   /**
    * Retrieves the list of groups a user has access to.

--- a/src/main/java/io/vinyldns/java/VinylDNSClient.java
+++ b/src/main/java/io/vinyldns/java/VinylDNSClient.java
@@ -160,5 +160,4 @@ public interface VinylDNSClient {
   // ToDo:   Get Group
   // ToDo:   Delete Group
   // ToDo:   Update Group
-  // ToDo:   Create Group
 }

--- a/src/main/java/io/vinyldns/java/VinylDNSClientImpl.java
+++ b/src/main/java/io/vinyldns/java/VinylDNSClientImpl.java
@@ -27,8 +27,7 @@ import io.vinyldns.java.model.batch.BatchResponse;
 import io.vinyldns.java.model.batch.CreateBatchRequest;
 import io.vinyldns.java.model.batch.ListBatchChangesRequest;
 import io.vinyldns.java.model.batch.ListBatchChangesResponse;
-import io.vinyldns.java.model.membership.ListGroupsRequest;
-import io.vinyldns.java.model.membership.ListGroupsResponse;
+import io.vinyldns.java.model.membership.*;
 import io.vinyldns.java.model.record.set.CreateRecordSetRequest;
 import io.vinyldns.java.model.record.set.DeleteRecordSetRequest;
 import io.vinyldns.java.model.record.set.ListRecordSetsRequest;
@@ -103,6 +102,13 @@ public class VinylDNSClientImpl implements VinylDNSClient {
     }
 
     return executeRequest(vinylDNSRequest, ListRecordSetsResponse.class);
+  }
+
+  @Override
+  public VinylDNSResponse<Group> createGroup(CreateGroupRequest request) {
+    return executeRequest(
+        new VinylDNSRequest<>(Methods.POST.name(), getBaseUrl(), "groups", request),
+        Group.class);
   }
 
   @Override

--- a/src/main/java/io/vinyldns/java/model/membership/CreateGroupRequest.java
+++ b/src/main/java/io/vinyldns/java/model/membership/CreateGroupRequest.java
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.vinyldns.java.model.membership;
 
 import java.util.Set;

--- a/src/main/java/io/vinyldns/java/model/membership/CreateGroupRequest.java
+++ b/src/main/java/io/vinyldns/java/model/membership/CreateGroupRequest.java
@@ -1,0 +1,76 @@
+package io.vinyldns.java.model.membership;
+
+import java.util.Set;
+
+public class CreateGroupRequest {
+    private final String name, email;
+    private String description; // optional
+    private final Set<MemberId> members, admins;
+
+    public CreateGroupRequest(String name, String email, Set<MemberId> members, Set<MemberId> admins) {
+        this.name = name;
+        this.email = email;
+        this.members = members;
+        this.admins = admins;
+    }
+
+    public CreateGroupRequest(String name, String email, Set<MemberId> members, Set<MemberId> admins, String description) {
+        this(name, email, members, admins);
+        this.description = description;
+    }
+
+    public String getName() { return name; }
+
+    public String getEmail() { return email; }
+
+    public void setDescription(String description) { this.description = description; }
+
+    public String getDescription() { return description; }
+
+    public Set<MemberId> getMembers() { return members; }
+
+    public Set<MemberId> getAdmins() { return admins; }
+
+    @Override
+    public String toString() {
+        return "CreateGroupRequest{"
+            + "name='"
+            + name
+            + '\''
+            + ", email='"
+            + email
+            + '\''
+            + ", description='"
+            + description
+            + '\''
+            + ", members="
+            + members
+            + ", admins"
+            + admins
+            + "}";
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        CreateGroupRequest group = (CreateGroupRequest) o;
+
+        if (!name.equals(group.name)) return false;
+        if (!email.equals(group.email)) return false;
+        if (description != null ? !description.equals(group.description) : group.description != null) return false;
+        if (!members.equals(group.members)) return false;
+        return admins.equals(group.admins);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = name.hashCode();
+        result = 31 * result + email.hashCode();
+        result = 31 * result + (description != null ? description.hashCode() : 0);
+        result = 31 * result + members.hashCode();
+        result = 31 * result + admins.hashCode();
+        return result;
+    }
+}

--- a/src/main/java/io/vinyldns/java/model/membership/Group.java
+++ b/src/main/java/io/vinyldns/java/model/membership/Group.java
@@ -9,22 +9,22 @@ public class Group {
     private String id, description; // optional
     private DateTime created; // optional
     private GroupStatus status;
-    private final Set<String> memberIds, adminUserIds;
+    private final Set<UserInfo> members, admins;
 
-    public Group(String name, String email, Set<String> memberIds, Set<String> adminUserIds) {
+    public Group(String name, String email, Set<UserInfo> members, Set<UserInfo> admins) {
         this.name = name;
         this.email = email;
-        this.memberIds = memberIds;
-        this.adminUserIds = adminUserIds;
+        this.members = members;
+        this.admins = admins;
     }
 
     public Group(String name, String email) {
         this(name, email, Collections.emptySet(), Collections.emptySet());
     }
 
-    public Group(String name, String email, Set<String> memberIds, Set<String> adminUserIds, String id,
+    public Group(String name, String email, Set<UserInfo> members, Set<UserInfo> admins, String id,
                  String description, DateTime created, GroupStatus status) {
-        this(name, email, memberIds, adminUserIds);
+        this(name, email, members, admins);
         this.id = id;
         this.description = description;
         this.created = created;
@@ -51,9 +51,9 @@ public class Group {
 
     public GroupStatus getStatus() { return status; }
 
-    public Set<String> getMemberIds() { return memberIds; }
+    public Set<UserInfo> getMembers() { return members; }
 
-    public Set<String> getAdminUserIds() { return adminUserIds; }
+    public Set<UserInfo> getAdmins() { return admins; }
 
     @Override
     public String toString() {
@@ -75,10 +75,10 @@ public class Group {
           + '\''
           + ", status="
           + status
-          + ", memberIds="
-          + memberIds
-          + ", adminUserIds="
-          + adminUserIds
+          + ", members="
+          + members
+          + ", admins="
+          + admins
           + '}';
     }
 
@@ -95,8 +95,8 @@ public class Group {
         if (!created.equals(group.created)) return false;
         if (description != null ? !description.equals(group.description) : group.description != null) return false;
         if (status != group.status) return false;
-        if (!memberIds.equals(group.memberIds)) return false;
-        return adminUserIds.equals(group.adminUserIds);
+        if (!members.equals(group.members)) return false;
+        return admins.equals(group.admins);
     }
 
     @Override
@@ -107,8 +107,8 @@ public class Group {
         result = 31 * result + created.hashCode();
         result = 31 * result + (description != null ? description.hashCode() : 0);
         result = 31 * result + status.hashCode();
-        result = 31 * result + memberIds.hashCode();
-        result = 31 * result + adminUserIds.hashCode();
+        result = 31 * result + members.hashCode();
+        result = 31 * result + admins.hashCode();
         return result;
     }
 }

--- a/src/main/java/io/vinyldns/java/model/membership/Group.java
+++ b/src/main/java/io/vinyldns/java/model/membership/Group.java
@@ -31,6 +31,10 @@ public class Group {
         this.status = status;
     }
 
+    public String getName() { return name; }
+
+    public String getEmail() { return email; }
+
     public void setId(String id) { this.id = id; }
 
     public String getId() { return id; }
@@ -46,6 +50,10 @@ public class Group {
     public void setStatus(GroupStatus status) { this.status = status; }
 
     public GroupStatus getStatus() { return status; }
+
+    public Set<String> getMemberIds() { return memberIds; }
+
+    public Set<String> getAdminUserIds() { return adminUserIds; }
 
     @Override
     public String toString() {

--- a/src/main/java/io/vinyldns/java/model/membership/Group.java
+++ b/src/main/java/io/vinyldns/java/model/membership/Group.java
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.vinyldns.java.model.membership;
 
 import java.util.Collections;

--- a/src/main/java/io/vinyldns/java/model/membership/GroupStatus.java
+++ b/src/main/java/io/vinyldns/java/model/membership/GroupStatus.java
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.vinyldns.java.model.membership;
 
 public enum GroupStatus {

--- a/src/main/java/io/vinyldns/java/model/membership/ListGroupsRequest.java
+++ b/src/main/java/io/vinyldns/java/model/membership/ListGroupsRequest.java
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.vinyldns.java.model.membership;
 
 public class ListGroupsRequest {

--- a/src/main/java/io/vinyldns/java/model/membership/ListGroupsResponse.java
+++ b/src/main/java/io/vinyldns/java/model/membership/ListGroupsResponse.java
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.vinyldns.java.model.membership;
 
 import java.util.Collection;

--- a/src/main/java/io/vinyldns/java/model/membership/LockStatus.java
+++ b/src/main/java/io/vinyldns/java/model/membership/LockStatus.java
@@ -1,0 +1,6 @@
+package io.vinyldns.java.model.membership;
+
+public enum LockStatus {
+    Locked,
+    Unlocked
+}

--- a/src/main/java/io/vinyldns/java/model/membership/LockStatus.java
+++ b/src/main/java/io/vinyldns/java/model/membership/LockStatus.java
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.vinyldns.java.model.membership;
 
 public enum LockStatus {

--- a/src/main/java/io/vinyldns/java/model/membership/MemberId.java
+++ b/src/main/java/io/vinyldns/java/model/membership/MemberId.java
@@ -1,0 +1,33 @@
+package io.vinyldns.java.model.membership;
+
+public class MemberId {
+    private final String id;
+    public MemberId(String id) {
+        this.id = id;
+    }
+
+    public String getId() { return id; }
+
+    @Override
+    public String toString() {
+        return "MemberId{"
+            + "id='"
+            + id
+            + "'}";
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        MemberId memberId = (MemberId) o;
+
+        return id.equals(memberId.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return id.hashCode();
+    }
+}

--- a/src/main/java/io/vinyldns/java/model/membership/MemberId.java
+++ b/src/main/java/io/vinyldns/java/model/membership/MemberId.java
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.vinyldns.java.model.membership;
 
 public class MemberId {

--- a/src/main/java/io/vinyldns/java/model/membership/UserInfo.java
+++ b/src/main/java/io/vinyldns/java/model/membership/UserInfo.java
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.vinyldns.java.model.membership;
 
 import io.vinyldns.java.model.zone.Zone;

--- a/src/main/java/io/vinyldns/java/model/membership/UserInfo.java
+++ b/src/main/java/io/vinyldns/java/model/membership/UserInfo.java
@@ -1,0 +1,106 @@
+package io.vinyldns.java.model.membership;
+
+import io.vinyldns.java.model.zone.Zone;
+import org.joda.time.DateTime;
+
+public class UserInfo {
+    private final String id;
+
+    // optional
+    private String userName, firstName, lastName, email;
+    private DateTime created;
+    private LockStatus lockStatus;
+
+    public UserInfo(String id) {
+        this.id = id;
+        this.lockStatus = LockStatus.Unlocked;
+    }
+
+    public UserInfo(String id, String userName, String firstName, String lastName, String email, DateTime created, LockStatus lockStatus) {
+        this.id = id;
+        this.userName = userName;
+        this.firstName = firstName;
+        this.lastName = lastName;
+        this.email = email;
+        this.created = created;
+        this.lockStatus = lockStatus;
+    }
+
+    public String getId() { return id; }
+
+    public String getUserName() { return userName; }
+
+    public void setUserName(String userName) { this.userName = userName; }
+
+    public String getFirstName() { return firstName; }
+
+    public void setFirstName(String firstName) { this.firstName = firstName; }
+
+    public String getLastName() { return lastName; }
+
+    public void setLastName(String lastName) { this.lastName = lastName; }
+
+    public String getEmail() { return email; }
+
+    public void setEmail(String email) { this.email = email; }
+
+    public DateTime getCreated() { return created; }
+
+    public void setCreated(DateTime created) { this.created = created; }
+
+    public LockStatus getLockStatus() { return lockStatus; }
+
+    public void setLockStatus(LockStatus lockStatus) { this.lockStatus = lockStatus; }
+
+    @Override
+    public String toString() {
+        return "UserInfo{"
+            + "id='"
+            + id
+            + '\''
+            + ", userName='"
+            + userName
+            + '\''
+            + ", firstName='"
+            + firstName
+            + '\''
+            + ", lastName='"
+            + lastName
+            + '\''
+            + ", email='"
+            + email
+            + '\''
+            + ", created="
+            + created
+            + ", lockStatus="
+            + lockStatus
+            + "}";
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        UserInfo userInfo = (UserInfo) o;
+        if (!id.equals(userInfo.id)) return false;
+        if (userName != null ? !userName.equals(userInfo.userName) : userInfo.userName != null) return false;
+        if (firstName != null ? !firstName.equals(userInfo.firstName) : userInfo.firstName != null) return false;
+        if (lastName != null ? !lastName.equals(userInfo.lastName) : userInfo.lastName != null) return false;
+        if (email != null ? !email.equals(userInfo.email) : userInfo.email != null) return false;
+        if (created != null ? !created.equals(userInfo.created) : userInfo.created != null) return false;
+        return lockStatus.equals(userInfo.lockStatus);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = id.hashCode();
+        result = 31 * result + (userName != null ? userName.hashCode() : 0);
+        result = 31 * result + (firstName != null ? firstName.hashCode() : 0);
+        result = 31 * result + (lastName != null ? lastName.hashCode() : 0);
+        result = 31 * result + (email != null ? email.hashCode() : 0);
+        result = 31 * result + (created != null ? created.hashCode() : 0);
+        result = 31 * result + lockStatus.hashCode();
+        return result;
+    }
+}


### PR DESCRIPTION
Implement create group method. Resolves #14.

Changes include:
- Fix `Group` response
- Add create group endpoint

------
Note for reviewers:
Tested the client against an instance of VinylDNS running on localhost using the following:
```
VinylDNSClient localClient =
    new VinylDNSClientImpl(
        new VinylDNSClientConfig(
            "http://localhost:9000",
            new BasicAWSCredentials("okAccessKey", "okSecretKey")));

VinylDNSResponse<Group> vinylDNSResponse = localClient.createGroup(new CreateGroupRequest("some-group", "some@email",
    Collections.singleton(new MemberId("ok")), Collections.singleton(new MemberId("ok"))));

System.out.println("response: " + vinylDNSResponse);
```

This produced the following response:
```
response: VinylDNSSuccessResponse{value=Group{name='some-group', email='some@email', description='null', id='708c813f-e84d-463a-a2b4-8b18cd8bb1d4', created='2019-02-20T22:42:24.000-05:00', status=Active, members=[UserInfo{id='ok', userName='null', firstName='null', lastName='null', email='null', created=null, lockStatus=Unlocked}], admins=[UserInfo{id='ok', userName='null', firstName='null', lastName='null', email='null', created=null, lockStatus=Unlocked}]}, statusCode=200}
```
