### PR TITLE
Implement updateRecordSet

### DIFF
--- a/src/main/java/io/vinyldns/java/VinylDNSClient.java
+++ b/src/main/java/io/vinyldns/java/VinylDNSClient.java
@@ -81,6 +81,16 @@ public interface VinylDNSClient {
   VinylDNSResponse<RecordSetChange> createRecordSet(CreateRecordSetRequest request);
 
   /**
+   * Update a RecordSet in a specified zone
+   *
+   * @param request See {@link UpdateRecordSetRequest UpdateRecordSetRequest Model}
+   * @return {@link VinylDNSSuccessResponse VinylDNSSuccessResponse&lt;RecordSetChange&gt;} in case
+   *     of success and {@link VinylDNSFailureResponse
+   *     VinylDNSFailureResponse&lt;RecordSetChange&gt;} in case of failure
+   */
+  VinylDNSResponse<RecordSetChange> updateRecordSet(UpdateRecordSetRequest request);
+
+  /**
    * Delete a RecordSet in a specified zone
    *
    * @param request See {@link DeleteRecordSetRequest DeleteRecordSetRequest Model}
@@ -90,7 +100,6 @@ public interface VinylDNSClient {
    */
   VinylDNSResponse<RecordSetChange> deleteRecordSet(DeleteRecordSetRequest request);
   // ToDo: List RecordSet Changes
-  // ToDo: Update RecordSet
 
   /**
    * Retrieves a RecordSetChange in a specified zone

--- a/src/main/java/io/vinyldns/java/VinylDNSClientImpl.java
+++ b/src/main/java/io/vinyldns/java/VinylDNSClientImpl.java
@@ -156,6 +156,14 @@ public class VinylDNSClientImpl implements VinylDNSClient {
   }
 
   @Override
+  public VinylDNSResponse<RecordSetChange> updateRecordSet(UpdateRecordSetRequest request) {
+    String path = "zones/" + request.getZoneId() + "/recordsets/" + request.getId();
+    return executeRequest(
+        new VinylDNSRequest<>(Methods.PUT.name(), getBaseUrl(), path, request),
+        RecordSetChange.class);
+  }
+
+  @Override
   public VinylDNSResponse<RecordSetChange> deleteRecordSet(DeleteRecordSetRequest request) {
     String path = "zones/" + request.getZoneId() + "/recordsets/" + request.getRecordSetId();
     return executeRequest(

--- a/src/main/java/io/vinyldns/java/model/record/set/UpdateRecordSetRequest.java
+++ b/src/main/java/io/vinyldns/java/model/record/set/UpdateRecordSetRequest.java
@@ -1,0 +1,25 @@
+package io.vinyldns.java.model.record.set;
+
+import io.vinyldns.java.model.record.RecordType;
+import io.vinyldns.java.model.record.data.RecordData;
+
+import java.util.Collection;
+
+public class UpdateRecordSetRequest extends RecordSet {
+    public UpdateRecordSetRequest() {}
+
+    public UpdateRecordSetRequest(String id, String zoneId, String name, RecordType type, long ttl, Collection<RecordData> records) {
+        super();
+        this.setId(id);
+        this.setZoneId(zoneId);
+        this.setName(name);
+        this.setType(type);
+        this.setTtl(ttl);
+        this.setRecords(records);
+    }
+
+    @Override
+    public String toString() {
+        return "UpdateRecordSetRequest{" + super.toString() + "}";
+    }
+}

--- a/src/main/java/io/vinyldns/java/model/record/set/UpdateRecordSetRequest.java
+++ b/src/main/java/io/vinyldns/java/model/record/set/UpdateRecordSetRequest.java
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.vinyldns.java.model.record.set;
 
 import io.vinyldns.java.model.record.RecordType;

--- a/src/main/java/io/vinyldns/java/model/zone/GetZoneResponse.java
+++ b/src/main/java/io/vinyldns/java/model/zone/GetZoneResponse.java
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.vinyldns.java.model.zone;
 
 public class GetZoneResponse {


### PR DESCRIPTION
Implement `updateRecordSet`. Resolves #10.

Changes in this request:
- Implement `updateRecordSet`
- Add tests

-------
Note for reviewers: Tested this against local instance of VinylDNS using the following:
```
VinylDNSClient localClient =
    new VinylDNSClientImpl(
        new VinylDNSClientConfig(
            "http://localhost:9000",
            new BasicAWSCredentials("testUserAccessKey", "testUserSecretKey")));

VinylDNSResponse<RecordSetChange> vinylDNSResponse =
    localClient.updateRecordSet(new UpdateRecordSetRequest("7d398177-f84b-430f-9d4e-b3999ffb27cb", "53718478-522c-4d6a-b652-06e6a6d35eaf",
        "already-exists-updated-again", RecordType.A, 200, Collections.singletonList(new AData("3.3.3.3"))));

System.out.println("response: " + vinylDNSResponse);
```

(The `id` and `zoneId` used above will have to be adjusted depending on values upon connecting to a zone.)

The following response was returned:
```
response: VinylDNSSuccessResponse{value=RecordSetChange{id='3bcba96a-9dc9-4ee2-886c-972408905721', zone=Zone{id='53718478-522c-4d6a-b652-06e6a6d35eaf', name='ok.', email='asda', status=Active, created=2019-02-20T23:49:43.000-05:00, updated=null, connection=null, transferConnection=null, shared=false, acl=ZoneACL{rules=[]}, adminGroupId='6d234523-2598-4009-b14c-c460703da544', latestSync=2019-02-20T23:49:44.000-05:00}, recordSet=RecordSet{id='7d398177-f84b-430f-9d4e-b3999ffb27cb'zoneId='53718478-522c-4d6a-b652-06e6a6d35eaf', name='already-exists-updated-again', type=A, ttl=200, records=[AData{address='3.3.3.3'}], status=PendingUpdate, created=2019-02-21T00:06:55.000-05:00, updated=2019-02-21T00:06:55.000-05:00}, userId='testuser', changeType=Update, status=Pending, created=2019-02-21T00:06:55.000-05:00, systemMessage='null', updates=RecordSet{id='7d398177-f84b-430f-9d4e-b3999ffb27cb'zoneId='53718478-522c-4d6a-b652-06e6a6d35eaf', name='already-exists-updated', type=A, ttl=200, records=[AData{address='3.3.3.3'}], status=Active, created=2019-02-20T23:52:00.000-05:00, updated=2019-02-20T23:52:00.000-05:00}}, statusCode=202}
```