### PR TITLE
Implement getRecordSet

### DIFF
--- a/src/main/java/io/vinyldns/java/VinylDNSClient.java
+++ b/src/main/java/io/vinyldns/java/VinylDNSClient.java
@@ -13,15 +13,8 @@
  */
 package io.vinyldns.java;
 
-import io.vinyldns.java.model.batch.BatchResponse;
-import io.vinyldns.java.model.batch.CreateBatchRequest;
-import io.vinyldns.java.model.batch.ListBatchChangesRequest;
-import io.vinyldns.java.model.batch.ListBatchChangesResponse;
-import io.vinyldns.java.model.membership.CreateGroupRequest;
-import io.vinyldns.java.model.membership.DeleteGroupRequest;
-import io.vinyldns.java.model.membership.Group;
-import io.vinyldns.java.model.membership.ListGroupsRequest;
-import io.vinyldns.java.model.membership.ListGroupsResponse;
+import io.vinyldns.java.model.batch.*;
+import io.vinyldns.java.model.membership.*;
 import io.vinyldns.java.model.record.set.*;
 import io.vinyldns.java.model.zone.*;
 import io.vinyldns.java.responses.VinylDNSFailureResponse;
@@ -68,6 +61,16 @@ public interface VinylDNSClient {
   VinylDNSResponse<ListRecordSetsResponse> listRecordSets(ListRecordSetsRequest request);
 
   /**
+   * Retrieves a RecordSet in a specified zone
+   *
+   * @param request See {@link GetRecordSetRequest CreateRecordSetRequest Model}
+   * @return {@link VinylDNSSuccessResponse VinylDNSSuccessResponse&lt;GetRecordSetResponse&gt;} in case
+   *     of success and {@link VinylDNSFailureResponse
+   *     VinylDNSFailureResponse&lt;RecordSetChange&gt;} in case of failure
+   */
+  VinylDNSResponse<GetRecordSetResponse> getRecordSet(GetRecordSetRequest request);
+
+  /**
    * Creates a RecordSet in a specified zone
    *
    * @param request See {@link CreateRecordSetRequest CreateRecordSetRequest Model}
@@ -87,7 +90,6 @@ public interface VinylDNSClient {
    */
   VinylDNSResponse<RecordSetChange> deleteRecordSet(DeleteRecordSetRequest request);
   // ToDo: List RecordSet Changes
-  // ToDo: Get RecordSet
   // ToDo: Update RecordSet
 
   /**

--- a/src/main/java/io/vinyldns/java/VinylDNSClient.java
+++ b/src/main/java/io/vinyldns/java/VinylDNSClient.java
@@ -63,10 +63,10 @@ public interface VinylDNSClient {
   /**
    * Retrieves a RecordSet in a specified zone
    *
-   * @param request See {@link GetRecordSetRequest CreateRecordSetRequest Model}
+   * @param request See {@link GetRecordSetRequest GetRecordSetRequest Model}
    * @return {@link VinylDNSSuccessResponse VinylDNSSuccessResponse&lt;GetRecordSetResponse&gt;} in case
    *     of success and {@link VinylDNSFailureResponse
-   *     VinylDNSFailureResponse&lt;RecordSetChange&gt;} in case of failure
+   *     VinylDNSFailureResponse&lt;GetRecordSetResponse&gt;} in case of failure
    */
   VinylDNSResponse<GetRecordSetResponse> getRecordSet(GetRecordSetRequest request);
 

--- a/src/main/java/io/vinyldns/java/VinylDNSClientImpl.java
+++ b/src/main/java/io/vinyldns/java/VinylDNSClientImpl.java
@@ -23,10 +23,7 @@ import com.google.gson.Gson;
 import io.vinyldns.java.handlers.ErrorResponseHandler;
 import io.vinyldns.java.handlers.StringResponseHandler;
 import io.vinyldns.java.model.Methods;
-import io.vinyldns.java.model.batch.BatchResponse;
-import io.vinyldns.java.model.batch.CreateBatchRequest;
-import io.vinyldns.java.model.batch.ListBatchChangesRequest;
-import io.vinyldns.java.model.batch.ListBatchChangesResponse;
+import io.vinyldns.java.model.batch.*;
 import io.vinyldns.java.model.membership.*;
 import io.vinyldns.java.model.record.set.*;
 import io.vinyldns.java.model.zone.*;
@@ -148,6 +145,14 @@ public class VinylDNSClientImpl implements VinylDNSClient {
     return executeRequest(
         new VinylDNSRequest<>(Methods.POST.name(), getBaseUrl(), path, request),
         RecordSetChange.class);
+  }
+
+  @Override
+  public VinylDNSResponse<GetRecordSetResponse> getRecordSet(GetRecordSetRequest request) {
+    String path = "zones/" + request.getZoneId() + "/recordsets/" + request.getRecordSetId();
+    return executeRequest(
+        new VinylDNSRequest<>(Methods.GET.name(), getBaseUrl(), path, null),
+        GetRecordSetResponse.class);
   }
 
   @Override

--- a/src/main/java/io/vinyldns/java/model/batch/GetRecordSetRequest.java
+++ b/src/main/java/io/vinyldns/java/model/batch/GetRecordSetRequest.java
@@ -1,4 +1,55 @@
+/**
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.vinyldns.java.model.batch;
 
 public class GetRecordSetRequest {
+    private final String recordSetId, zoneId;
+
+    public GetRecordSetRequest(String zoneId, String recordSetId) {
+        this.zoneId = zoneId;
+        this.recordSetId = recordSetId;
+    }
+
+    public String getRecordSetId() { return recordSetId; }
+
+    public String getZoneId() { return zoneId; }
+
+    @Override
+    public String toString() {
+        return "GetRecordSetRequest{"
+            + "recordSetId='"
+            + recordSetId
+            + "\'"
+            + ", zoneId='"
+            + zoneId
+            + "'}";
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        GetRecordSetRequest that = (GetRecordSetRequest) o;
+        if (!zoneId.equals(that.zoneId)) return false;
+        return recordSetId.equals(that.recordSetId);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = zoneId.hashCode();
+        result = 31 * result + recordSetId.hashCode();
+        return result;
+    }
 }

--- a/src/main/java/io/vinyldns/java/model/batch/GetRecordSetRequest.java
+++ b/src/main/java/io/vinyldns/java/model/batch/GetRecordSetRequest.java
@@ -1,0 +1,4 @@
+package io.vinyldns.java.model.batch;
+
+public class GetRecordSetRequest {
+}

--- a/src/main/java/io/vinyldns/java/model/zone/GetRecordSetResponse.java
+++ b/src/main/java/io/vinyldns/java/model/zone/GetRecordSetResponse.java
@@ -1,0 +1,4 @@
+package io.vinyldns.java.model.zone;
+
+public class GetRecordSetResponse {
+}

--- a/src/main/java/io/vinyldns/java/model/zone/GetRecordSetResponse.java
+++ b/src/main/java/io/vinyldns/java/model/zone/GetRecordSetResponse.java
@@ -1,4 +1,45 @@
+/**
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.vinyldns.java.model.zone;
 
+import io.vinyldns.java.model.record.set.RecordSet;
+
 public class GetRecordSetResponse {
+    private final RecordSet recordSet;
+
+    public GetRecordSetResponse(RecordSet recordSet) {
+        this.recordSet = recordSet;
+    }
+
+    public RecordSet getRecordSet() { return recordSet; }
+
+    @Override
+    public String toString() {
+        return "GetRecordSetResponse{recordSet=" + recordSet.toString() + "}";
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        GetRecordSetResponse that = (GetRecordSetResponse) o;
+        return recordSet.equals(that.recordSet);
+    }
+
+    @Override
+    public int hashCode() {
+        return recordSet.hashCode();
+    }
 }

--- a/src/test/java/io/vinyldns/java/VinylDNSClientTest.java
+++ b/src/test/java/io/vinyldns/java/VinylDNSClientTest.java
@@ -231,7 +231,6 @@ public class VinylDNSClientTest {
                     .withHeader("Content-Type", "application/json")
                     .withBody(response)));
 
-
     VinylDNSResponse<GetRecordSetResponse> vinylDNSResponse = client.getRecordSet(getRecordSetRequest);
 
     assertTrue(vinylDNSResponse instanceof ResponseMarker.Success);

--- a/src/test/java/io/vinyldns/java/VinylDNSClientTest.java
+++ b/src/test/java/io/vinyldns/java/VinylDNSClientTest.java
@@ -22,6 +22,7 @@ import com.amazonaws.auth.BasicAWSCredentials;
 import com.github.tomakehurst.wiremock.WireMockServer;
 import io.vinyldns.java.model.acl.ACLRule;
 import io.vinyldns.java.model.acl.AccessLevel;
+import io.vinyldns.java.model.batch.GetRecordSetRequest;
 import io.vinyldns.java.model.membership.*;
 import io.vinyldns.java.model.record.RecordType;
 import io.vinyldns.java.model.record.data.AData;
@@ -218,6 +219,55 @@ public class VinylDNSClientTest {
   }
 
   @Test
+  public void getRecordSetSuccess() {
+    GetRecordSetResponse getRecordSetResponse = new GetRecordSetResponse(recordSet);
+    String response = client.gson.toJson(getRecordSetResponse);
+
+    wireMockServer.stubFor(
+        get(urlEqualTo("/zones/" + zoneId + "/recordsets/" + recordSetId))
+            .willReturn(
+                aResponse()
+                    .withStatus(200)
+                    .withHeader("Content-Type", "application/json")
+                    .withBody(response)));
+
+
+    VinylDNSResponse<GetRecordSetResponse> vinylDNSResponse = client.getRecordSet(getRecordSetRequest);
+
+    assertTrue(vinylDNSResponse instanceof ResponseMarker.Success);
+    assertEquals(vinylDNSResponse.getStatusCode(), 200);
+    assertEquals(vinylDNSResponse.getValue(), getRecordSetResponse);
+  }
+
+  @Test
+  public void getRecordSetFailure() {
+    wireMockServer.stubFor(
+        get(urlEqualTo("/zones/" + zoneId + "/recordsets/" + recordSetId))
+            .willReturn(aResponse().withStatus(500).withBody("server error")));
+
+    VinylDNSResponse<GetRecordSetResponse> vinylDNSResponse = client.getRecordSet(getRecordSetRequest);
+
+    assertTrue(vinylDNSResponse instanceof ResponseMarker.Failure);
+    assertEquals(vinylDNSResponse.getStatusCode(), 500);
+    assertEquals(vinylDNSResponse.getMessageBody(), "server error");
+    assertNull(vinylDNSResponse.getValue());
+  }
+
+  @Test
+  public void getRecordSetFailure404() {
+    wireMockServer.stubFor(
+        get(urlEqualTo("/zones/" + zoneId + "/recordsets/" + recordSetId))
+            .willReturn(aResponse().withStatus(404).withBody("not found")));
+
+    VinylDNSResponse<GetRecordSetResponse> vinylDNSResponse = client.getRecordSet(getRecordSetRequest);
+
+    assertTrue(vinylDNSResponse instanceof ResponseMarker.Failure);
+    assertEquals(vinylDNSResponse.getStatusCode(), 404);
+    assertEquals(vinylDNSResponse.getMessageBody(), "not found");
+    assertNull(vinylDNSResponse.getValue());
+  }
+
+  @Test
   public void deleteRecordSetsSuccess() {
     String response = client.gson.toJson(recordSetChangeDelete);
 
@@ -335,11 +385,11 @@ public class VinylDNSClientTest {
                     .withHeader("Content-Type", "application/json")
                     .withBody(response)));
 
-    VinylDNSResponse<Group> vinylDNSResponse = client.getGroup(getGroupRequest);
+    VinylDNSResponse<RecordSetChange> vinylDNSResponse = client.getRecordSetChange(getRecordSetChangeRequest);
 
     assertTrue(vinylDNSResponse instanceof ResponseMarker.Success);
     assertEquals(vinylDNSResponse.getStatusCode(), 200);
-    assertEquals(vinylDNSResponse.getValue(), group);
+    assertEquals(vinylDNSResponse.getValue(), recordSetChangeCreate);
   }
 
   @Test
@@ -654,6 +704,8 @@ public class VinylDNSClientTest {
           null);
   private CreateRecordSetRequest createRecordSetRequest =
       new CreateRecordSetRequest(zoneId, recordSetName, RecordType.A, 100, recordDataList);
+  private GetRecordSetRequest getRecordSetRequest =
+      new GetRecordSetRequest(zoneId, recordSetId);
 
   private String groupId = "groupId";
   private GetRecordSetChangeRequest getRecordSetChangeRequest =


### PR DESCRIPTION
Implement `getRecordSet` method. Resolves #11.

Changes include:
- Add models for `getRecordSet`
- Add `getRecordSet` method
- Add tests

-------
Note for reviewers: The following code was used to test against a local instance of VinylDNS:
```
VinylDNSClient localClient =
    new VinylDNSClientImpl(
        new VinylDNSClientConfig(
            "http://localhost:9000",
            new BasicAWSCredentials("testUserAccessKey", "testUserSecretKey")));

VinylDNSResponse<GetRecordSetResponse> vinylDNSResponse =
    localClient.getRecordSet(new GetRecordSetRequest("53718478-522c-4d6a-b652-06e6a6d35eaf","7d398177-f84b-430f-9d4e-b3999ffb27cb"));

System.out.println("response: " + vinylDNSResponse);
```

(`zoneId` and `recordSetId` will depend on your generated values.)

The following is the response:
```
response: VinylDNSSuccessResponse{value=GetRecordSetResponse{recordSet=RecordSet{id='7d398177-f84b-430f-9d4e-b3999ffb27cb'zoneId='53718478-522c-4d6a-b652-06e6a6d35eaf', name='already-exists-updated-again', type=A, ttl=200, records=[AData{address='3.3.3.3'}], status=Active, created=2019-02-21T00:06:55.000-05:00, updated=2019-02-21T00:06:55.000-05:00}}, statusCode=200}
```