### PR TITLE
Implement getRecordSetChange

### DIFF
--- a/src/main/java/io/vinyldns/java/VinylDNSClient.java
+++ b/src/main/java/io/vinyldns/java/VinylDNSClient.java
@@ -22,11 +22,7 @@ import io.vinyldns.java.model.membership.DeleteGroupRequest;
 import io.vinyldns.java.model.membership.Group;
 import io.vinyldns.java.model.membership.ListGroupsRequest;
 import io.vinyldns.java.model.membership.ListGroupsResponse;
-import io.vinyldns.java.model.record.set.CreateRecordSetRequest;
-import io.vinyldns.java.model.record.set.DeleteRecordSetRequest;
-import io.vinyldns.java.model.record.set.ListRecordSetsRequest;
-import io.vinyldns.java.model.record.set.ListRecordSetsResponse;
-import io.vinyldns.java.model.record.set.RecordSetChange;
+import io.vinyldns.java.model.record.set.*;
 import io.vinyldns.java.model.zone.*;
 import io.vinyldns.java.responses.VinylDNSFailureResponse;
 import io.vinyldns.java.responses.VinylDNSResponse;
@@ -93,7 +89,16 @@ public interface VinylDNSClient {
   // ToDo: List RecordSet Changes
   // ToDo: Get RecordSet
   // ToDo: Update RecordSet
-  // ToDo: Get RecordSet Change
+
+  /**
+   * Retrieves a RecordSetChange in a specified zone
+   *
+   * @param request See {@link GetRecordSetChangeRequest GetRecordSetChangeRequest Model}
+   * @return {@link VinylDNSSuccessResponse VinylDNSSuccessResponse&lt;RecordSetChange&gt;} in case
+   *     of success and {@link VinylDNSFailureResponse
+   *     VinylDNSFailureResponse&lt;RecordSetChange&gt;} in case of failure
+   */
+  VinylDNSResponse<RecordSetChange> getRecordSetChange(GetRecordSetChangeRequest request);
 
   // Groups
   /**

--- a/src/main/java/io/vinyldns/java/VinylDNSClientImpl.java
+++ b/src/main/java/io/vinyldns/java/VinylDNSClientImpl.java
@@ -28,11 +28,7 @@ import io.vinyldns.java.model.batch.CreateBatchRequest;
 import io.vinyldns.java.model.batch.ListBatchChangesRequest;
 import io.vinyldns.java.model.batch.ListBatchChangesResponse;
 import io.vinyldns.java.model.membership.*;
-import io.vinyldns.java.model.record.set.CreateRecordSetRequest;
-import io.vinyldns.java.model.record.set.DeleteRecordSetRequest;
-import io.vinyldns.java.model.record.set.ListRecordSetsRequest;
-import io.vinyldns.java.model.record.set.ListRecordSetsResponse;
-import io.vinyldns.java.model.record.set.RecordSetChange;
+import io.vinyldns.java.model.record.set.*;
 import io.vinyldns.java.model.zone.*;
 import io.vinyldns.java.responses.VinylDNSFailureResponse;
 import io.vinyldns.java.responses.VinylDNSResponse;
@@ -159,6 +155,15 @@ public class VinylDNSClientImpl implements VinylDNSClient {
     String path = "zones/" + request.getZoneId() + "/recordsets/" + request.getRecordSetId();
     return executeRequest(
         new VinylDNSRequest<>(Methods.DELETE.name(), getBaseUrl(), path, null),
+        RecordSetChange.class);
+  }
+
+  @Override
+  public VinylDNSResponse<RecordSetChange> getRecordSetChange(GetRecordSetChangeRequest request) {
+    String path = "zones/" + request.getZoneId() + "/recordsets/" + request.getRecordSetId() + "/changes/"
+        + request.getRecordSetChangeId();
+    return executeRequest(
+        new VinylDNSRequest<>(Methods.GET.name(), getBaseUrl(), path, null),
         RecordSetChange.class);
   }
 

--- a/src/main/java/io/vinyldns/java/model/record/set/GetRecordSetChangeRequest.java
+++ b/src/main/java/io/vinyldns/java/model/record/set/GetRecordSetChangeRequest.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.vinyldns.java.model.record.set;
+
+public class GetRecordSetChangeRequest {
+    private final String zoneId, recordSetId, recordSetChangeId;
+
+    public GetRecordSetChangeRequest(String zoneId, String recordSetId, String recordSetChangeId) {
+        this.zoneId = zoneId;
+        this.recordSetId = recordSetId;
+        this.recordSetChangeId = recordSetChangeId;
+    }
+
+    public String getZoneId() { return zoneId; }
+
+    public String getRecordSetId() { return recordSetId; }
+
+    public String getRecordSetChangeId() { return recordSetChangeId; }
+
+    @Override
+    public String toString() {
+        return "GetRecordSetChangeRequest{"
+            + "zoneId='"
+            + zoneId
+            + "\'"
+            + ", recordSetId='"
+            + recordSetId
+            + "\'"
+            + ", recordSetChangeId='"
+            + recordSetChangeId
+            + "\'"
+            + "}";
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        GetRecordSetChangeRequest that = (GetRecordSetChangeRequest) o;
+        if (!zoneId.equals(that.zoneId)) return false;
+        if (!recordSetId.equals(that.recordSetId)) return false;
+        return recordSetChangeId.equals(that.getRecordSetChangeId());
+    }
+
+    @Override
+    public int hashCode() {
+        int result = zoneId.hashCode();
+        result = 31 * result + recordSetId.hashCode();
+        result = 31 * result + recordSetChangeId.hashCode();
+        return result;
+    }
+}


### PR DESCRIPTION
Implement `getRecordSetChange`. Resolves #12.

Changes include:
- Add `GetRecordSetChangeRequest` model and `getRecordSetChange` method
- Add tests

--------
Note to reviewers: The following code was ran against a local instance of VinylDNS:
```
VinylDNSClient localClient =
    new VinylDNSClientImpl(
        new VinylDNSClientConfig(
            "http://localhost:9000",
            new BasicAWSCredentials("testUserAccessKey", "testUserSecretKey")));

VinylDNSResponse<RecordSetChange> vinylDNSResponse =
    localClient.getRecordSetChange(new GetRecordSetChangeRequest("abd86f50-8f57-4401-bf63-1d4931cb78db", "a543d993-f5e9-4edf-bea7-26441825a687", "7442b4a2-d6bc-4790-a4e7-81586ca89796"));

System.out.println("response: " + vinylDNSResponse);
```

This resulted in the following response:
```
response: VinylDNSSuccessResponse{value=RecordSetChange{id='7442b4a2-d6bc-4790-a4e7-81586ca89796', zone=Zone{id='abd86f50-8f57-4401-bf63-1d4931cb78db', name='ok.', email='asdsa', status=Syncing, created=2019-02-21T21:38:37.000-05:00, updated=null, connection=null, transferConnection=null, shared=false, acl=ZoneACL{rules=[]}, adminGroupId='38f5a45d-ab32-406d-b00e-85ef2a9e92eb', latestSync=null}, recordSet=RecordSet{id='a543d993-f5e9-4edf-bea7-26441825a687'zoneId='abd86f50-8f57-4401-bf63-1d4931cb78db', name='foo', type=A, ttl=38400, records=[AData{address='2.2.2.2'}], status=Active, created=2019-02-21T21:38:37.000-05:00, updated=null}, userId='testuser', changeType=Create, status=Complete, created=2019-02-21T21:38:37.000-05:00, systemMessage='Change applied via zone sync', updates=null}, statusCode=200}
```