### PR TITLE
Implement getGroup

### DIFF
--- a/src/main/java/io/vinyldns/java/GetGroupRequest.java
+++ b/src/main/java/io/vinyldns/java/GetGroupRequest.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.vinyldns.java;
+
+public class GetGroupRequest {
+    private final String id;
+
+    public GetGroupRequest(String id) {
+        this.id = id;
+    }
+
+    public String getId() { return id; }
+
+    @Override
+    public String toString() {
+        return "GetZoneRequest{id='" + id + "'}";
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        GetGroupRequest that = (GetGroupRequest) o;
+        return id.equals(that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return id.hashCode();
+    }
+}

--- a/src/main/java/io/vinyldns/java/VinylDNSClient.java
+++ b/src/main/java/io/vinyldns/java/VinylDNSClient.java
@@ -106,6 +106,16 @@ public interface VinylDNSClient {
   VinylDNSResponse<Group> createGroup(CreateGroupRequest request);
 
   /**
+   * Retrieves a group by ID
+   *
+   * @param request See {@link GetGroupRequest GetGroupRequest Model}
+   * @return {@link VinylDNSSuccessResponse VinylDNSSuccessResponse&lt;Group&gt;} in case
+   *     of success and {@link VinylDNSFailureResponse VinylDNSFailureResponse&lt;Group&gt;} in case
+   *     of failure.
+   */
+  VinylDNSResponse<Group> getGroup(GetGroupRequest request);
+
+  /**
    * Retrieves the list of groups a user has access to.
    *
    * @param request See {@link ListGroupsRequest ListGroupsRequest Model}
@@ -157,7 +167,6 @@ public interface VinylDNSClient {
   // ToDo:   List Group Members
   // ToDo:   List Group Admins
   // ToDo:   List Groups
-  // ToDo:   Get Group
   // ToDo:   Delete Group
   // ToDo:   Update Group
 }

--- a/src/main/java/io/vinyldns/java/VinylDNSClientImpl.java
+++ b/src/main/java/io/vinyldns/java/VinylDNSClientImpl.java
@@ -112,6 +112,13 @@ public class VinylDNSClientImpl implements VinylDNSClient {
   }
 
   @Override
+  public VinylDNSResponse<Group> getGroup(GetGroupRequest request) {
+    String path = "groups/" + request.getId();
+    return executeRequest(
+        new VinylDNSRequest<>(Methods.GET.name(), getBaseUrl(), path, null), Group.class);
+  }
+
+  @Override
   public VinylDNSResponse<ListGroupsResponse> listGroups(ListGroupsRequest request) {
     VinylDNSRequest<Void> vinylDNSRequest =
         new VinylDNSRequest<>(Methods.GET.name(), getBaseUrl(), "groups", null);

--- a/src/test/java/io/vinyldns/java/VinylDNSClientTest.java
+++ b/src/test/java/io/vinyldns/java/VinylDNSClientTest.java
@@ -377,6 +377,53 @@ public class VinylDNSClientTest {
   }
 
   @Test
+  public void getGroupSuccess() {
+    String response = client.gson.toJson(group);
+
+    wireMockServer.stubFor(
+        get(urlEqualTo("/groups/" + groupId))
+            .willReturn(
+                aResponse()
+                    .withStatus(200)
+                    .withHeader("Content-Type", "application/json")
+                    .withBody(response)));
+
+    VinylDNSResponse<Group> vinylDNSResponse = client.getGroup(getGroupRequest);
+
+    assertTrue(vinylDNSResponse instanceof ResponseMarker.Success);
+    assertEquals(vinylDNSResponse.getStatusCode(), 200);
+    assertEquals(vinylDNSResponse.getValue(), group);
+  }
+
+  @Test
+  public void getGroupFailure() {
+    wireMockServer.stubFor(
+        get(urlEqualTo("/groups/" + groupId))
+            .willReturn(aResponse().withStatus(500).withBody("server error")));
+
+    VinylDNSResponse<Group> vinylDNSResponse = client.getGroup(getGroupRequest);
+
+    assertTrue(vinylDNSResponse instanceof ResponseMarker.Failure);
+    assertEquals(vinylDNSResponse.getStatusCode(), 500);
+    assertEquals(vinylDNSResponse.getMessageBody(), "server error");
+    assertNull(vinylDNSResponse.getValue());
+  }
+
+  @Test
+  public void getGroupFailure404() {
+    wireMockServer.stubFor(
+        get(urlEqualTo("/groups/" + groupId))
+            .willReturn(aResponse().withStatus(404).withBody("not found")));
+
+    VinylDNSResponse<Group> vinylDNSResponse = client.getGroup(getGroupRequest);
+
+    assertTrue(vinylDNSResponse instanceof ResponseMarker.Failure);
+    assertEquals(vinylDNSResponse.getStatusCode(), 404);
+    assertEquals(vinylDNSResponse.getMessageBody(), "not found");
+    assertNull(vinylDNSResponse.getValue());
+  }
+
+  @Test
   public void listGroupsSuccessWithParams() {
       String response = client.gson.toJson(listGroupsResponse);
 
@@ -514,6 +561,7 @@ public class VinylDNSClientTest {
   private CreateRecordSetRequest createRecordSetRequest =
       new CreateRecordSetRequest(zoneId, recordSetName, RecordType.A, 100, recordDataList);
 
+  private String groupId = "groupId";
   private String adminId = "adminId";
   private Set<UserInfo> adminUserInfo = Collections.singleton(new UserInfo(adminId));
   private Set<MemberId> adminMemberId = Collections.singleton(new MemberId(adminId));
@@ -529,6 +577,8 @@ public class VinylDNSClientTest {
 
   private CreateGroupRequest createGroupRequest =
     new CreateGroupRequest("createGroup", "create@group.com", adminMemberId, adminMemberId);
+  private GetGroupRequest getGroupRequest =
+      new GetGroupRequest(groupId);
 
   private List<Group> groupList = Collections.singletonList(group);
 


### PR DESCRIPTION
Implement `getGroup` method. Resolves #17.

Changes include:
- Implement `getGroup`
- Add tests

----------
Note to reviewers: Tested this against a local instance of VinylDNS:
```
VinylDNSClient localClient =
    new VinylDNSClientImpl(
        new VinylDNSClientConfig(
            "http://localhost:9000",
            new BasicAWSCredentials("testUserAccessKey", "testUserSecretKey")));

VinylDNSResponse<Group> vinylDNSResponse = localClient.getGroup(new GetGroupRequest("140e108d-0b52-4030-8958-c210ceda9997"));

System.out.println("response: " + vinylDNSResponse);
```

This resulted in the following response:
```
response: VinylDNSSuccessResponse{value=Group{name='fsd', email='sdfsd', description='null', id='140e108d-0b52-4030-8958-c210ceda9997', created='2019-02-24T18:49:31.000-05:00', status=Active, memberIds=null, adminUserIds=null}, statusCode=200}
```