### PR TITLE
Implement deleteGroup

### DIFF
--- a/src/main/java/io/vinyldns/java/VinylDNSClient.java
+++ b/src/main/java/io/vinyldns/java/VinylDNSClient.java
@@ -18,6 +18,7 @@ import io.vinyldns.java.model.batch.CreateBatchRequest;
 import io.vinyldns.java.model.batch.ListBatchChangesRequest;
 import io.vinyldns.java.model.batch.ListBatchChangesResponse;
 import io.vinyldns.java.model.membership.CreateGroupRequest;
+import io.vinyldns.java.model.membership.DeleteGroupRequest;
 import io.vinyldns.java.model.membership.Group;
 import io.vinyldns.java.model.membership.ListGroupsRequest;
 import io.vinyldns.java.model.membership.ListGroupsResponse;
@@ -96,6 +97,16 @@ public interface VinylDNSClient {
 
   // Groups
   /**
+   * Retrieves a group by ID
+   *
+   * @param request See {@link GetGroupRequest GetGroupRequest Model}
+   * @return {@link VinylDNSSuccessResponse VinylDNSSuccessResponse&lt;Group&gt;} in case
+   *     of success and {@link VinylDNSFailureResponse VinylDNSFailureResponse&lt;Group&gt;} in case
+   *     of failure.
+   */
+  VinylDNSResponse<Group> getGroup(GetGroupRequest request);
+
+  /**
    * Create a group.
    *
    * @param request See {@link CreateGroupRequest CreateGroupRequest Model}
@@ -106,14 +117,14 @@ public interface VinylDNSClient {
   VinylDNSResponse<Group> createGroup(CreateGroupRequest request);
 
   /**
-   * Retrieves a group by ID
+   * Delete a group with a specific ID
    *
-   * @param request See {@link GetGroupRequest GetGroupRequest Model}
+   * @param request See {@link DeleteGroupRequest DeleteGroupRequest Model}
    * @return {@link VinylDNSSuccessResponse VinylDNSSuccessResponse&lt;Group&gt;} in case
    *     of success and {@link VinylDNSFailureResponse VinylDNSFailureResponse&lt;Group&gt;} in case
    *     of failure.
    */
-  VinylDNSResponse<Group> getGroup(GetGroupRequest request);
+  VinylDNSResponse<Group> deleteGroup(DeleteGroupRequest request);
 
   /**
    * Retrieves the list of groups a user has access to.
@@ -167,6 +178,5 @@ public interface VinylDNSClient {
   // ToDo:   List Group Members
   // ToDo:   List Group Admins
   // ToDo:   List Groups
-  // ToDo:   Delete Group
   // ToDo:   Update Group
 }

--- a/src/main/java/io/vinyldns/java/VinylDNSClientImpl.java
+++ b/src/main/java/io/vinyldns/java/VinylDNSClientImpl.java
@@ -105,6 +105,13 @@ public class VinylDNSClientImpl implements VinylDNSClient {
   }
 
   @Override
+  public VinylDNSResponse<Group> getGroup(GetGroupRequest request) {
+    String path = "groups/" + request.getId();
+    return executeRequest(
+        new VinylDNSRequest<>(Methods.GET.name(), getBaseUrl(), path, null), Group.class);
+  }
+
+  @Override
   public VinylDNSResponse<Group> createGroup(CreateGroupRequest request) {
     return executeRequest(
         new VinylDNSRequest<>(Methods.POST.name(), getBaseUrl(), "groups", request),
@@ -112,10 +119,11 @@ public class VinylDNSClientImpl implements VinylDNSClient {
   }
 
   @Override
-  public VinylDNSResponse<Group> getGroup(GetGroupRequest request) {
-    String path = "groups/" + request.getId();
+  public VinylDNSResponse<Group> deleteGroup(DeleteGroupRequest request) {
+    String path = "/groups/" + request.getId();
     return executeRequest(
-        new VinylDNSRequest<>(Methods.GET.name(), getBaseUrl(), path, null), Group.class);
+        new VinylDNSRequest<>(Methods.DELETE.name(), getBaseUrl(), path, null),
+        Group.class);
   }
 
   @Override

--- a/src/main/java/io/vinyldns/java/model/membership/DeleteGroupRequest.java
+++ b/src/main/java/io/vinyldns/java/model/membership/DeleteGroupRequest.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.vinyldns.java.model.membership;
+
+public class DeleteGroupRequest {
+    private final String id;
+
+    public DeleteGroupRequest(String id) {
+        this.id = id;
+    }
+
+    public String getId() { return id; }
+
+    @Override
+    public String toString() {
+        return "DeleteGroupRequest{id='" + id + "'}";
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        DeleteGroupRequest that = (DeleteGroupRequest) o;
+        return id.equals(that.getId());
+    }
+
+    @Override
+    public int hashCode() {
+        return id.hashCode();
+    }
+}

--- a/src/test/java/io/vinyldns/java/VinylDNSClientTest.java
+++ b/src/test/java/io/vinyldns/java/VinylDNSClientTest.java
@@ -324,6 +324,53 @@ public class VinylDNSClientTest {
   }
 
   @Test
+  public void getGroupSuccess() {
+    String response = client.gson.toJson(group);
+
+    wireMockServer.stubFor(
+        get(urlEqualTo("/groups/" + groupId))
+            .willReturn(
+                aResponse()
+                    .withStatus(200)
+                    .withHeader("Content-Type", "application/json")
+                    .withBody(response)));
+
+    VinylDNSResponse<Group> vinylDNSResponse = client.getGroup(getGroupRequest);
+
+    assertTrue(vinylDNSResponse instanceof ResponseMarker.Success);
+    assertEquals(vinylDNSResponse.getStatusCode(), 200);
+    assertEquals(vinylDNSResponse.getValue(), group);
+  }
+
+  @Test
+  public void getGroupFailure() {
+    wireMockServer.stubFor(
+        get(urlEqualTo("/groups/" + groupId))
+            .willReturn(aResponse().withStatus(500).withBody("server error")));
+
+    VinylDNSResponse<Group> vinylDNSResponse = client.getGroup(getGroupRequest);
+
+    assertTrue(vinylDNSResponse instanceof ResponseMarker.Failure);
+    assertEquals(vinylDNSResponse.getStatusCode(), 500);
+    assertEquals(vinylDNSResponse.getMessageBody(), "server error");
+    assertNull(vinylDNSResponse.getValue());
+  }
+
+  @Test
+  public void getGroupFailure404() {
+    wireMockServer.stubFor(
+        get(urlEqualTo("/groups/" + groupId))
+            .willReturn(aResponse().withStatus(404).withBody("not found")));
+
+    VinylDNSResponse<Group> vinylDNSResponse = client.getGroup(getGroupRequest);
+
+    assertTrue(vinylDNSResponse instanceof ResponseMarker.Failure);
+    assertEquals(vinylDNSResponse.getStatusCode(), 404);
+    assertEquals(vinylDNSResponse.getMessageBody(), "not found");
+    assertNull(vinylDNSResponse.getValue());
+  }
+
+  @Test
   public void createGroupSuccess() {
     String request = client.gson.toJson(createGroupRequest);
     String response = client.gson.toJson(group);
@@ -377,18 +424,18 @@ public class VinylDNSClientTest {
   }
 
   @Test
-  public void getGroupSuccess() {
+  public void deleteGroupSuccess() {
     String response = client.gson.toJson(group);
 
     wireMockServer.stubFor(
-        get(urlEqualTo("/groups/" + groupId))
+        delete(urlEqualTo("/groups/" + groupId))
             .willReturn(
                 aResponse()
                     .withStatus(200)
                     .withHeader("Content-Type", "application/json")
                     .withBody(response)));
 
-    VinylDNSResponse<Group> vinylDNSResponse = client.getGroup(getGroupRequest);
+    VinylDNSResponse<Group> vinylDNSResponse = client.deleteGroup(deleteGroupRequest);
 
     assertTrue(vinylDNSResponse instanceof ResponseMarker.Success);
     assertEquals(vinylDNSResponse.getStatusCode(), 200);
@@ -396,12 +443,12 @@ public class VinylDNSClientTest {
   }
 
   @Test
-  public void getGroupFailure() {
+  public void deleteGroupFailure() {
     wireMockServer.stubFor(
-        get(urlEqualTo("/groups/" + groupId))
+        delete(urlEqualTo("/groups/" + groupId))
             .willReturn(aResponse().withStatus(500).withBody("server error")));
 
-    VinylDNSResponse<Group> vinylDNSResponse = client.getGroup(getGroupRequest);
+    VinylDNSResponse<Group> vinylDNSResponse = client.deleteGroup(deleteGroupRequest);
 
     assertTrue(vinylDNSResponse instanceof ResponseMarker.Failure);
     assertEquals(vinylDNSResponse.getStatusCode(), 500);
@@ -410,12 +457,12 @@ public class VinylDNSClientTest {
   }
 
   @Test
-  public void getGroupFailure404() {
+  public void deleteGroupFailure404() {
     wireMockServer.stubFor(
-        get(urlEqualTo("/groups/" + groupId))
+        delete(urlEqualTo("/groups/" + groupId))
             .willReturn(aResponse().withStatus(404).withBody("not found")));
 
-    VinylDNSResponse<Group> vinylDNSResponse = client.getGroup(getGroupRequest);
+    VinylDNSResponse<Group> vinylDNSResponse = client.deleteGroup(deleteGroupRequest);
 
     assertTrue(vinylDNSResponse instanceof ResponseMarker.Failure);
     assertEquals(vinylDNSResponse.getStatusCode(), 404);
@@ -575,10 +622,13 @@ public class VinylDNSClientTest {
           new DateTime(),
           Active);
 
+
   private CreateGroupRequest createGroupRequest =
     new CreateGroupRequest("createGroup", "create@group.com", adminMemberId, adminMemberId);
   private GetGroupRequest getGroupRequest =
       new GetGroupRequest(groupId);
+  private DeleteGroupRequest deleteGroupRequest =
+      new DeleteGroupRequest(groupId);
 
   private List<Group> groupList = Collections.singletonList(group);
 


### PR DESCRIPTION
Implement `deleteGroup`. Resolves #16.

Changes in this PR:
- Implement `deleteGroup`
- Add tests

---------
Note to reviewers: The following was run against a local instance of VinylDNS:
```
VinylDNSClient localClient =
    new VinylDNSClientImpl(
        new VinylDNSClientConfig(
            "http://localhost:9000",
            new BasicAWSCredentials("testUserAccessKey", "testUserSecretKey")));

VinylDNSResponse<Group> vinylDNSResponse = localClient.deleteGroup(new DeleteGroupRequest("fc0c89a5-49fb-4d4a-be46-cd4efe801444"));

System.out.println("response: " + vinylDNSResponse);
```

This resulted in the following response:
```
response: VinylDNSSuccessResponse{value=Group{name='sadsa', email='asdas', description='null', id='fc0c89a5-49fb-4d4a-be46-cd4efe801444', created='2019-02-25T18:52:19.000-05:00', status=Deleted, memberIds=null, adminUserIds=null}, statusCode=200}
```