### PR TITLE
rename typ to type

### DIFF
--- a/src/main/java/io/vinyldns/java/model/batch/DeleteRecordSetSingleChange.java
+++ b/src/main/java/io/vinyldns/java/model/batch/DeleteRecordSetSingleChange.java
@@ -23,7 +23,7 @@ public class DeleteRecordSetSingleChange implements SingleChange {
   private String zoneName;
   private String recordName;
   private String inputName;
-  private RecordType typ;
+  private RecordType type;
   private SingleChangeStatus status;
   private String systemMessage;
   private String recordChangeId;
@@ -85,11 +85,11 @@ public class DeleteRecordSetSingleChange implements SingleChange {
 
   @Override
   public RecordType getType() {
-    return typ;
+    return type;
   }
 
-  public void setTyp(RecordType typ) {
-    this.typ = typ;
+  public void setType(RecordType type) {
+    this.type = type;
   }
 
   @Override
@@ -147,8 +147,8 @@ public class DeleteRecordSetSingleChange implements SingleChange {
         + ", inputName='"
         + inputName
         + '\''
-        + ", typ="
-        + typ
+        + ", type="
+        + type
         + ", status="
         + status
         + ", systemMessage='"
@@ -174,7 +174,7 @@ public class DeleteRecordSetSingleChange implements SingleChange {
         && Objects.equals(zoneName, that.zoneName)
         && Objects.equals(recordName, that.recordName)
         && Objects.equals(inputName, that.inputName)
-        && typ == that.typ
+        && type == that.type
         && status == that.status
         && Objects.equals(systemMessage, that.systemMessage)
         && Objects.equals(recordChangeId, that.recordChangeId)
@@ -191,7 +191,7 @@ public class DeleteRecordSetSingleChange implements SingleChange {
         zoneName,
         recordName,
         inputName,
-        typ,
+        type,
         status,
         systemMessage,
         recordChangeId,

--- a/src/main/java/io/vinyldns/java/model/record/data/SSHFPData.java
+++ b/src/main/java/io/vinyldns/java/model/record/data/SSHFPData.java
@@ -15,14 +15,14 @@ package io.vinyldns.java.model.record.data;
 
 public class SSHFPData implements RecordData {
   private int algorithm;
-  private int typ;
+  private int type;
   private String fingerprint;
 
   public SSHFPData() {}
 
   public SSHFPData(int algorithm, int typ, String fingerprint) {
     this.algorithm = algorithm;
-    this.typ = typ;
+    this.type = typ;
     this.fingerprint = fingerprint;
   }
 
@@ -34,12 +34,12 @@ public class SSHFPData implements RecordData {
     this.algorithm = algorithm;
   }
 
-  public int getTyp() {
-    return typ;
+  public int getType() {
+    return type;
   }
 
-  public void setTyp(int typ) {
-    this.typ = typ;
+  public void setType(int type) {
+    this.type = type;
   }
 
   public String getFingerprint() {
@@ -55,8 +55,8 @@ public class SSHFPData implements RecordData {
     return "SSHFPData{"
         + "algorithm="
         + algorithm
-        + ", typ="
-        + typ
+        + ", type="
+        + type
         + ", fingerprint='"
         + fingerprint
         + '\''
@@ -71,14 +71,14 @@ public class SSHFPData implements RecordData {
     SSHFPData sshfpData = (SSHFPData) o;
 
     if (algorithm != sshfpData.algorithm) return false;
-    if (typ != sshfpData.typ) return false;
+    if (type != sshfpData.type) return false;
     return fingerprint.equals(sshfpData.fingerprint);
   }
 
   @Override
   public int hashCode() {
     int result = algorithm;
-    result = 31 * result + typ;
+    result = 31 * result + type;
     result = 31 * result + fingerprint.hashCode();
     return result;
   }

--- a/src/test/java/io/vinyldns/java/VinylDNSClientTest.java
+++ b/src/test/java/io/vinyldns/java/VinylDNSClientTest.java
@@ -1143,7 +1143,7 @@ public class VinylDNSClientTest {
     deleteSingleChange.setRecordSetId("testId");
     deleteSingleChange.setZoneId("testZone");
     deleteSingleChange.setZoneName("testZoneName");
-    deleteSingleChange.setTyp(RecordType.A);
+    deleteSingleChange.setType(RecordType.A);
     deleteSingleChange.setSystemMessage("testMessage");
     deleteSingleChange.setStatus(SingleChangeStatus.Complete);
 


### PR DESCRIPTION
fixes #71 

delete single change input and sshfp `typ` attr in the API is serialized to `type` 