### PR TITLE
Add new group change route and fix attributes

### DIFF
--- a/src/main/java/io/vinyldns/java/VinylDNSClient.java
+++ b/src/main/java/io/vinyldns/java/VinylDNSClient.java
@@ -259,6 +259,17 @@ public interface VinylDNSClient {
    */
   VinylDNSResponse<ListGroupActivityResponse> listGroupActivity(ListGroupActivityRequest request);
 
+    /**
+   * Retrieves a group change for a groupChangeId.
+   *
+   * @param request See {@link GetGroupChangeRequest GetGroupChangeRequest}
+   * @return {@link VinylDNSSuccessResponse
+   *     VinylDNSSuccessResponse&lt;GroupChange&gt;} in case of success and {@link
+   *     VinylDNSFailureResponse VinylDNSFailureResponse&lt;GroupChange&gt;} in case
+   *     of failure.
+   */
+  VinylDNSResponse<GroupChange> getGroupChange(GetGroupChangeRequest request);
+
   // Batch
   /**
    * Retrieves the most recent 100 batch changes created by the user. This call will return a subset

--- a/src/main/java/io/vinyldns/java/VinylDNSClientImpl.java
+++ b/src/main/java/io/vinyldns/java/VinylDNSClientImpl.java
@@ -258,6 +258,17 @@ public class VinylDNSClientImpl implements VinylDNSClient {
   }
 
   @Override
+  public VinylDNSResponse<GroupChange> getGroupChange(
+      GetGroupChangeRequest request) {
+    String path = "groups/change/" + request.getId();
+
+    VinylDNSRequest<Void> vinylDNSRequest =
+        new VinylDNSRequest<>(Methods.GET.name(), getBaseUrl(), path, null);
+
+    return executeRequest(vinylDNSRequest, GroupChange.class);
+  }
+
+  @Override
   public VinylDNSResponse<RecordSetChange> createRecordSet(CreateRecordSetRequest request) {
     String path = "zones/" + request.getZoneId() + "/recordsets";
     return executeRequest(

--- a/src/main/java/io/vinyldns/java/model/membership/GetGroupChangeRequest.java
+++ b/src/main/java/io/vinyldns/java/model/membership/GetGroupChangeRequest.java
@@ -13,10 +13,10 @@
  */
 package io.vinyldns.java;
 
-public class GetGroupRequest {
+public class GetGroupChangeRequest {
   private final String id;
 
-  public GetGroupRequest(String id) {
+  public GetGroupChangeRequest(String id) {
     this.id = id;
   }
 
@@ -26,7 +26,7 @@ public class GetGroupRequest {
 
   @Override
   public String toString() {
-    return "ZoneRequest{id='" + id + "'}";
+    return "GroupChangeRequest{id='" + id + "'}";
   }
 
   @Override
@@ -34,7 +34,7 @@ public class GetGroupRequest {
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;
 
-    GetGroupRequest that = (GetGroupRequest) o;
+    GetGroupChangeRequest that = (GetGroupChangeRequest) o;
     return id.equals(that.id);
   }
 

--- a/src/main/java/io/vinyldns/java/model/membership/GetGroupRequest.java
+++ b/src/main/java/io/vinyldns/java/model/membership/GetGroupRequest.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.vinyldns.java;
+
+public class GetGroupRequest {
+  private final String id;
+
+  public GetGroupRequest(String id) {
+    this.id = id;
+  }
+
+  public String getId() {
+    return id;
+  }
+
+  @Override
+  public String toString() {
+    return "GroupRequest{id='" + id + "'}";
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+
+    GetGroupRequest that = (GetGroupRequest) o;
+    return id.equals(that.id);
+  }
+
+  @Override
+  public int hashCode() {
+    return id.hashCode();
+  }
+}

--- a/src/main/java/io/vinyldns/java/model/membership/ListGroupActivityResponse.java
+++ b/src/main/java/io/vinyldns/java/model/membership/ListGroupActivityResponse.java
@@ -17,7 +17,7 @@ import java.util.Set;
 
 public class ListGroupActivityResponse {
   private final Set<GroupChange> changes;
-  private String startFrom, nextId; // optional
+  private Integer startFrom, nextId; // optional
   private final Integer maxItems;
 
   public ListGroupActivityResponse(Set<GroupChange> changes, Integer maxItems) {
@@ -26,7 +26,7 @@ public class ListGroupActivityResponse {
   }
 
   public ListGroupActivityResponse(
-      Set<GroupChange> changes, String startFrom, String nextId, Integer maxItems) {
+      Set<GroupChange> changes, Integer startFrom, Integer nextId, Integer maxItems) {
     this.changes = changes;
     this.startFrom = startFrom;
     this.nextId = nextId;
@@ -37,11 +37,11 @@ public class ListGroupActivityResponse {
     return changes;
   }
 
-  public String getStartFrom() {
+  public Integer getStartFrom() {
     return startFrom;
   }
 
-  public void setStartFrom(String startFrom) {
+  public void setStartFrom(Integer startFrom) {
     this.startFrom = startFrom;
   }
 
@@ -53,11 +53,11 @@ public class ListGroupActivityResponse {
     return changes;
   }
 
-  public String getNextId() {
+  public Integer getNextId() {
     return nextId;
   }
 
-  public void setNextId(String nextId) {
+  public void setNextId(Integer nextId) {
     this.nextId = nextId;
   }
 

--- a/src/main/java/io/vinyldns/java/model/record/set/ListRecordSetChangesResponse.java
+++ b/src/main/java/io/vinyldns/java/model/record/set/ListRecordSetChangesResponse.java
@@ -19,15 +19,15 @@ import java.util.Objects;
 public class ListRecordSetChangesResponse {
   private String zoneId;
   private List<RecordSetChange> recordSetChanges;
-  private String nextId; // optional
-  private String startFrom; // optional
+  private Integer nextId; // optional
+  private Integer startFrom; // optional
   private Integer maxItems;
 
   public ListRecordSetChangesResponse(
       String zoneId,
       List<RecordSetChange> recordSetChanges,
-      String nextId,
-      String startFrom,
+      Integer nextId,
+      Integer startFrom,
       Integer maxItems) {
     this.zoneId = zoneId;
     this.recordSetChanges = recordSetChanges;
@@ -52,19 +52,19 @@ public class ListRecordSetChangesResponse {
     this.recordSetChanges = recordSetChanges;
   }
 
-  public String getNextId() {
+  public Integer getNextId() {
     return nextId;
   }
 
-  public void setNextId(String nextId) {
+  public void setNextId(Integer nextId) {
     this.nextId = nextId;
   }
 
-  public String getStartFrom() {
+  public Integer getStartFrom() {
     return startFrom;
   }
 
-  public void setStartFrom(String startFrom) {
+  public void setStartFrom(Integer startFrom) {
     this.startFrom = startFrom;
   }
 


### PR DESCRIPTION
- Added the new group change route.
- Change `nextId` and `startFrom` from string to int as per the [change here](https://github.com/vinyldns/vinyldns/blob/1e1b105eb8ebbcf4fc3b6dbee62562c8d98d547d/modules/api/src/main/scala/vinyldns/api/domain/record/ListRecordSetChangesResponse.scala#L25-L26) for recordset change to payload and response data.
- Change `startFrom` and `nextId` from string to int as per the [change here](https://github.com/vinyldns/vinyldns/blob/9afe8d3e4bd321ce0b14f1a9d89c0817d9ea568c/modules/api/src/main/scala/vinyldns/api/route/MembershipRouting.scala#L165-L166) for group change to payload and response data.