### PR TITLE
Add missing VinylDNS API endpoints

### DIFF
--- a/src/main/java/io/vinyldns/java/VinylDNSClient.java
+++ b/src/main/java/io/vinyldns/java/VinylDNSClient.java
@@ -1,25 +1,30 @@
-/**
+/*
  * Copyright 2018 Comcast Cable Communications Management, LLC
  *
- * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
- * except in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * <p>Unless required by applicable law or agreed to in writing, software distributed under the
- * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing permissions and
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
  * limitations under the License.
  */
 package io.vinyldns.java;
 
+import io.vinyldns.java.model.acl.*;
 import io.vinyldns.java.model.batch.*;
+import io.vinyldns.java.model.health.*;
 import io.vinyldns.java.model.membership.*;
 import io.vinyldns.java.model.record.set.*;
 import io.vinyldns.java.model.zone.*;
 import io.vinyldns.java.responses.VinylDNSFailureResponse;
 import io.vinyldns.java.responses.VinylDNSResponse;
 import io.vinyldns.java.responses.VinylDNSSuccessResponse;
+import java.util.List;
 
 public interface VinylDNSClient {
   // Zone
@@ -364,11 +369,247 @@ public interface VinylDNSClient {
    * minimum of two alpha-numeric characters is required.
    *
    * @param request See {@link SearchRecordSetsRequest SearchRecordSetsRequest Model}
+   * @return {@link VinylDNSSuccessResponse VinylDNSSuccessResponse&lt;SearchRecordSetsResponse&gt;}
+   *     in case of success and {@link VinylDNSFailureResponse
+   *     VinylDNSFailureResponse&lt;SearchRecordSetsResponse&gt;} in case of failure
+   */
+  VinylDNSResponse<SearchRecordSetsResponse> searchRecordSets(SearchRecordSetsRequest request);
+
+  /**
+   * Retrieves a user by ID.
+   *
+   * @param request See {@link GetUserRequest GetUserRequest Model}
+   * @return {@link VinylDNSSuccessResponse VinylDNSSuccessResponse&lt;GetUserResponse&gt;} in case
+   *     of success and {@link VinylDNSFailureResponse
+   *     VinylDNSFailureResponse&lt;GetUserResponse&gt;} in case of failure
+   */
+  VinylDNSResponse<GetUserResponse> getUser(GetUserRequest request);
+
+  /**
+   * Locks a user account (admin only).
+   *
+   * @param request See {@link LockUserRequest LockUserRequest Model}
+   * @return {@link VinylDNSSuccessResponse VinylDNSSuccessResponse&lt;LockUnlockUserResponse&gt;}
+   *     in case of success and {@link VinylDNSFailureResponse
+   *     VinylDNSFailureResponse&lt;LockUnlockUserResponse&gt;} in case of failure
+   */
+  VinylDNSResponse<LockUnlockUserResponse> lockUser(LockUserRequest request);
+
+  /**
+   * Unlocks a user account (admin only).
+   *
+   * @param request See {@link UnlockUserRequest UnlockUserRequest Model}
+   * @return {@link VinylDNSSuccessResponse VinylDNSSuccessResponse&lt;LockUnlockUserResponse&gt;}
+   *     in case of success and {@link VinylDNSFailureResponse
+   *     VinylDNSFailureResponse&lt;LockUnlockUserResponse&gt;} in case of failure
+   */
+  VinylDNSResponse<LockUnlockUserResponse> unlockUser(UnlockUserRequest request);
+
+  /**
+   * Retrieves details of a specific group change.
+   *
+   * @param request See {@link GetGroupChangeRequest GetGroupChangeRequest Model}
+   * @return {@link VinylDNSSuccessResponse VinylDNSSuccessResponse&lt;GetGroupChangeResponse&gt;}
+   *     in case of success and {@link VinylDNSFailureResponse
+   *     VinylDNSFailureResponse&lt;GetGroupChangeResponse&gt;} in case of failure
+   */
+  VinylDNSResponse<GetGroupChangeResponse> getGroupChange(GetGroupChangeRequest request);
+
+  /**
+   * Retrieves the list of valid email domains for groups.
+   *
+   * @return {@link VinylDNSSuccessResponse VinylDNSSuccessResponse&lt;ListValidDomainsResponse&gt;}
+   *     in case of success and {@link VinylDNSFailureResponse
+   *     VinylDNSFailureResponse&lt;ListValidDomainsResponse&gt;} in case of failure
+   */
+  VinylDNSResponse<List<String>> listValidDomains();
+
+  /**
+   * Retrieves record set count for a zone.
+   *
+   * @param request See {@link GetRecordSetCountRequest GetRecordSetCountRequest Model}
    * @return {@link VinylDNSSuccessResponse
-   *     VinylDNSSuccessResponse&lt;SearchRecordSetsResponse&gt;} in case of success and {@link
-   *     VinylDNSFailureResponse VinylDNSFailureResponse&lt;SearchRecordSetsResponse&gt;} in case
+   *     VinylDNSSuccessResponse&lt;GetRecordSetCountResponse&gt;} in case of success and {@link
+   *     VinylDNSFailureResponse VinylDNSFailureResponse&lt;GetRecordSetCountResponse&gt;} in case
    *     of failure
    */
-  VinylDNSResponse<SearchRecordSetsResponse> searchRecordSets(
-          SearchRecordSetsRequest request);
+  VinylDNSResponse<GetRecordSetCountResponse> getRecordSetCount(GetRecordSetCountRequest request);
+
+  /**
+   * Retrieves record set change history for a given FQDN/type.
+   *
+   * @param request See {@link GetRecordSetChangeHistoryRequest}
+   * @return {@code VinylDNSSuccessResponse<GetRecordSetChangeHistoryResponse>} in case of success
+   *     and {@code VinylDNSFailureResponse<GetRecordSetChangeHistoryResponse>} in case of failure
+   */
+  VinylDNSResponse<GetRecordSetChangeHistoryResponse> getRecordSetChangeHistory(
+      GetRecordSetChangeHistoryRequest request);
+
+  /**
+   * Retrieves failed record set changes count for a zone.
+   *
+   * @param request See {@link GetFailedRecordSetChangesRequest GetFailedRecordSetChangesRequest
+   *     Model}
+   * @return {@link VinylDNSSuccessResponse
+   *     VinylDNSSuccessResponse&lt;GetFailedRecordSetChangesResponse&gt;} in case of success and
+   *     {@link VinylDNSFailureResponse
+   *     VinylDNSFailureResponse&lt;GetFailedRecordSetChangesResponse&gt;} in case of failure
+   */
+  VinylDNSResponse<GetFailedRecordSetChangesResponse> getFailedRecordSetChanges(
+      GetFailedRecordSetChangesRequest request);
+
+  /**
+   * Retrieves detailed zone info along with the effective access level for the current principal.
+   *
+   * @param request See {@link GetZoneDetailsRequest GetZoneDetailsRequest Model}
+   * @return {@link VinylDNSSuccessResponse VinylDNSSuccessResponse&lt;GetZoneDetailsResponse&gt;}
+   *     in case of success and {@link VinylDNSFailureResponse
+   *     VinylDNSFailureResponse&lt;GetZoneDetailsResponse&gt;} in case of failure
+   */
+  VinylDNSResponse<GetZoneDetailsResponse> getZoneDetails(GetZoneDetailsRequest request);
+
+  /**
+   * Lists available DNS backend IDs that can be used for zones.
+   *
+   * @return {@link VinylDNSSuccessResponse
+   *     VinylDNSSuccessResponse&lt;GetZonesBackendIdsResponse&gt;} in case of success and {@link
+   *     VinylDNSFailureResponse VinylDNSFailureResponse&lt;GetZonesBackendIdsResponse&gt;} in case
+   *     of failure
+   */
+  VinylDNSResponse<List<String>> getZonesBackendIds();
+
+  /**
+   * Retrieves the failed zone changes count (global health metric).
+   *
+   * @param request See {@link GetFailedZoneChangesRequest GetFailedZoneChangesRequest Model}
+   * @return {@link VinylDNSSuccessResponse
+   *     VinylDNSSuccessResponse&lt;GetFailedZoneChangesResponse&gt;} in case of success and {@link
+   *     VinylDNSFailureResponse VinylDNSFailureResponse&lt;GetFailedZoneChangesResponse&gt;} in
+   *     case of failure
+   */
+  VinylDNSResponse<GetFailedZoneChangesResponse> getFailedZoneChanges(
+      GetFailedZoneChangesRequest request);
+
+  /**
+   * Adds an ACL rule to a zone.
+   *
+   * @param request See {@link AddZoneAclRuleRequest AddZoneAclRuleRequest Model}
+   * @return {@link VinylDNSSuccessResponse VinylDNSSuccessResponse&lt;AddZoneAclRuleResponse&gt;}
+   *     in case of success and {@link VinylDNSFailureResponse
+   *     VinylDNSFailureResponse&lt;AddZoneAclRuleResponse&gt;} in case of failure
+   */
+  VinylDNSResponse<AddZoneAclRuleResponse> addZoneAclRule(AddZoneAclRuleRequest request);
+
+  /**
+   * Deletes an ACL rule from a zone.
+   *
+   * @param request See {@link DeleteZoneAclRuleRequest DeleteZoneAclRuleRequest Model}
+   * @return {@link VinylDNSSuccessResponse
+   *     VinylDNSSuccessResponse&lt;DeleteZoneAclRuleResponse&gt;} in case of success and {@link
+   *     VinylDNSFailureResponse VinylDNSFailureResponse&lt;DeleteZoneAclRuleResponse&gt;} in case
+   *     of failure
+   */
+  VinylDNSResponse<DeleteZoneAclRuleResponse> deleteZoneAclRule(DeleteZoneAclRuleRequest request);
+  // VinylDNSResponse<DeleteZoneAclRuleResponse> deleteZoneAclRule(String zoneId, ACLRule rule);
+
+  /**
+   * Simple health check.
+   *
+   * @return {@link VinylDNSSuccessResponse VinylDNSSuccessResponse&lt;GetPingResponse&gt;} in case
+   *     of success and {@link VinylDNSFailureResponse
+   *     VinylDNSFailureResponse&lt;GetPingResponse&gt;} in case of failure
+   */
+  VinylDNSResponse<String> getPing();
+
+  /**
+   * Comprehensive health check including subsystem statuses.
+   *
+   * @return {@link VinylDNSSuccessResponse VinylDNSSuccessResponse&lt;GetHealthResponse&gt;} in
+   *     case of success and {@link VinylDNSFailureResponse
+   *     VinylDNSFailureResponse&lt;GetHealthResponse&gt;} in case of failure
+   */
+  VinylDNSResponse<String> getHealth();
+
+  /**
+   * Returns current deployment color (blue/green).
+   *
+   * @return {@link VinylDNSSuccessResponse VinylDNSSuccessResponse&lt;GetColorResponse&gt;} in case
+   *     of success and {@link VinylDNSFailureResponse
+   *     VinylDNSFailureResponse&lt;GetColorResponse&gt;} in case of failure
+   */
+  VinylDNSResponse<String> getColor();
+
+  /**
+   * Prometheus metrics in text/plain exposition format.
+   *
+   * @return {@link VinylDNSSuccessResponse
+   *     VinylDNSSuccessResponse&lt;GetPrometheusMetricsResponse&gt;} in case of success and {@link
+   *     VinylDNSFailureResponse VinylDNSFailureResponse&lt;GetPrometheusMetricsResponse&gt;} in
+   *     case of failure
+   */
+  VinylDNSResponse<String> getPrometheusMetrics();
+
+  /**
+   * Retrieves system processing status (enabled/disabled).
+   *
+   * @param request See {@link GetStatusRequest GetStatusRequest Model}
+   * @return {@link VinylDNSSuccessResponse VinylDNSSuccessResponse&lt;StatusResponse&gt;} in case
+   *     of success and {@link VinylDNSFailureResponse
+   *     VinylDNSFailureResponse&lt;StatusResponse&gt;} in case of failure
+   */
+  VinylDNSResponse<StatusResponse> getStatus(GetStatusRequest request);
+
+  /**
+   * Updates system processing status (admin: enable/disable).
+   *
+   * @param request See {@link UpdateStatusRequest UpdateStatusRequest Model}
+   * @return {@link VinylDNSSuccessResponse VinylDNSSuccessResponse&lt;StatusResponse&gt;} in case
+   *     of success and {@link VinylDNSFailureResponse
+   *     VinylDNSFailureResponse&lt;StatusResponse&gt;} in case of failure
+   */
+  VinylDNSResponse<StatusResponse> updateStatus(UpdateStatusRequest request);
+
+  /**
+   * Requests ownership transfer for a record seFt.
+   *
+   * @param request See {@link RecordSetOwnershipTransferRequest RecordSetOwnershipTransferRequest}
+   * @return {@link VinylDNSResponse VinylDNSSuccessResponse&lt;RecordSetUpdateResponse&gt;} in case
+   *     of success and {@link VinylDNSResponse
+   *     VinylDNSFailureResponse&lt;RecordSetUpdateResponse&gt;} in case of failure
+   */
+  VinylDNSResponse<RecordSetUpdateResponse> requestTransfer(
+      RecordSetOwnershipTransferRequest request);
+
+  /**
+   * Approves a pending ownership transfer request.
+   *
+   * @param request See {@link RecordSetOwnershipTransferRequest RecordSetOwnershipTransferRequest}
+   * @return {@link VinylDNSResponse VinylDNSSuccessResponse&lt;RecordSetUpdateResponse&gt;} in case
+   *     of success and {@link VinylDNSResponse
+   *     VinylDNSFailureResponse&lt;RecordSetUpdateResponse&gt;} in case of failure
+   */
+  VinylDNSResponse<RecordSetUpdateResponse> approveTransfer(
+      RecordSetOwnershipTransferRequest request);
+
+  /**
+   * Rejects a pending ownership transfer request.
+   *
+   * @param request See {@link RecordSetOwnershipTransferRequest RecordSetOwnershipTransferRequest}
+   * @return {@link VinylDNSResponse VinylDNSSuccessResponse&lt;RecordSetUpdateResponse&gt;} in case
+   *     of success and {@link VinylDNSResponse
+   *     VinylDNSFailureResponse&lt;RecordSetUpdateResponse&gt;} in case of failure
+   */
+  VinylDNSResponse<RecordSetUpdateResponse> rejectTransfer(
+      RecordSetOwnershipTransferRequest request);
+
+  /**
+   * Cancels a pending ownership transfer request.
+   *
+   * @param request See {@link RecordSetOwnershipTransferRequest RecordSetOwnershipTransferRequest}
+   * @return {@link VinylDNSResponse VinylDNSSuccessResponse&lt;RecordSetUpdateResponse&gt;} in case
+   *     of success and {@link VinylDNSResponse
+   *     VinylDNSFailureResponse&lt;RecordSetUpdateResponse&gt;} in case of failure
+   */
+  VinylDNSResponse<RecordSetUpdateResponse> cancelTransfer(
+      RecordSetOwnershipTransferRequest request);
 }

--- a/src/main/java/io/vinyldns/java/VinylDNSClient.java
+++ b/src/main/java/io/vinyldns/java/VinylDNSClient.java
@@ -418,9 +418,9 @@ public interface VinylDNSClient {
   /**
    * Retrieves the list of valid email domains for groups.
    *
-   * @return {@link VinylDNSSuccessResponse VinylDNSSuccessResponse&lt;ListValidDomainsResponse&gt;}
-   *     in case of success and {@link VinylDNSFailureResponse
-   *     VinylDNSFailureResponse&lt;ListValidDomainsResponse&gt;} in case of failure
+   * @return {@link VinylDNSSuccessResponse VinylDNSSuccessResponse&lt;List&lt;String&gt;&gt;} in
+   *     case of success and {@link VinylDNSFailureResponse
+   *     VinylDNSFailureResponse&lt;List&lt;String&gt;&gt;} in case of failure
    */
   VinylDNSResponse<List<String>> listValidDomains();
 
@@ -471,10 +471,9 @@ public interface VinylDNSClient {
   /**
    * Lists available DNS backend IDs that can be used for zones.
    *
-   * @return {@link VinylDNSSuccessResponse
-   *     VinylDNSSuccessResponse&lt;GetZonesBackendIdsResponse&gt;} in case of success and {@link
-   *     VinylDNSFailureResponse VinylDNSFailureResponse&lt;GetZonesBackendIdsResponse&gt;} in case
-   *     of failure
+   * @return {@link VinylDNSSuccessResponse VinylDNSSuccessResponse&lt;List&lt;String&gt;&gt;} in
+   *     case of success and {@link VinylDNSFailureResponse
+   *     VinylDNSFailureResponse&lt;List&lt;String&gt;&gt;} in case of failure
    */
   VinylDNSResponse<List<String>> getZonesBackendIds();
 
@@ -515,37 +514,36 @@ public interface VinylDNSClient {
   /**
    * Simple health check.
    *
-   * @return {@link VinylDNSSuccessResponse VinylDNSSuccessResponse&lt;GetPingResponse&gt;} in case
-   *     of success and {@link VinylDNSFailureResponse
-   *     VinylDNSFailureResponse&lt;GetPingResponse&gt;} in case of failure
+   * @return {@link VinylDNSSuccessResponse VinylDNSSuccessResponse&lt;String&gt;} in case of
+   *     success and {@link VinylDNSFailureResponse VinylDNSFailureResponse&lt;String&gt;} in case
+   *     of failure
    */
   VinylDNSResponse<String> getPing();
 
   /**
    * Comprehensive health check including subsystem statuses.
    *
-   * @return {@link VinylDNSSuccessResponse VinylDNSSuccessResponse&lt;GetHealthResponse&gt;} in
-   *     case of success and {@link VinylDNSFailureResponse
-   *     VinylDNSFailureResponse&lt;GetHealthResponse&gt;} in case of failure
+   * @return {@link VinylDNSSuccessResponse VinylDNSSuccessResponse&lt;String&gt;} in case of
+   *     success and {@link VinylDNSFailureResponse VinylDNSFailureResponse&lt;String&gt;} in case
+   *     of failure
    */
   VinylDNSResponse<String> getHealth();
 
   /**
    * Returns current deployment color (blue/green).
    *
-   * @return {@link VinylDNSSuccessResponse VinylDNSSuccessResponse&lt;GetColorResponse&gt;} in case
-   *     of success and {@link VinylDNSFailureResponse
-   *     VinylDNSFailureResponse&lt;GetColorResponse&gt;} in case of failure
+   * @return {@link VinylDNSSuccessResponse VinylDNSSuccessResponse&lt;String&gt;} in case of
+   *     success and {@link VinylDNSFailureResponse VinylDNSFailureResponse&lt;String&gt;} in case
+   *     of failure
    */
   VinylDNSResponse<String> getColor();
 
   /**
    * Prometheus metrics in text/plain exposition format.
    *
-   * @return {@link VinylDNSSuccessResponse
-   *     VinylDNSSuccessResponse&lt;GetPrometheusMetricsResponse&gt;} in case of success and {@link
-   *     VinylDNSFailureResponse VinylDNSFailureResponse&lt;GetPrometheusMetricsResponse&gt;} in
-   *     case of failure
+   * @return {@link VinylDNSSuccessResponse VinylDNSSuccessResponse&lt;String&gt;} in case of
+   *     success and {@link VinylDNSFailureResponse VinylDNSFailureResponse&lt;String&gt;} in case
+   *     of failure
    */
   VinylDNSResponse<String> getPrometheusMetrics();
 
@@ -570,7 +568,7 @@ public interface VinylDNSClient {
   VinylDNSResponse<StatusResponse> updateStatus(UpdateStatusRequest request);
 
   /**
-   * Requests ownership transfer for a record seFt.
+   * Requests ownership transfer for a record set.
    *
    * @param request See {@link RecordSetOwnershipTransferRequest RecordSetOwnershipTransferRequest}
    * @return {@link VinylDNSResponse VinylDNSSuccessResponse&lt;RecordSetUpdateResponse&gt;} in case

--- a/src/main/java/io/vinyldns/java/VinylDNSClientImpl.java
+++ b/src/main/java/io/vinyldns/java/VinylDNSClientImpl.java
@@ -934,53 +934,6 @@ public class VinylDNSClientImpl implements VinylDNSClient {
     }
   }
 
-  //   private <S, R> VinylDNSResponse<R> executeRequest(VinylDNSRequest<S> req, Class<R>
-  //   responseType) {
-  //     Request<String> request = new DefaultRequest<>("VinylDNS");
-  //     request.setEndpoint(req.getEndpoint());
-  //     request.setResourcePath(req.getResourcePath());
-  //     request.setHttpMethod(req.getHttpMethod());
-  //     request.setHeaders(req.getHeaders());
-  //     request.setParameters(req.getParameters());
-  //     request.addHeader("Content-Type", "application/json");
-
-  //     if (req.getPayload() != null) {
-  //       // String content = gson.toJson(req.getPayload());
-  //       // request.setContent(new
-  // ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8)));
-  //       byte[] payload = gson.toJson(request.getRule()).getBytes(StandardCharsets.UTF_8);
-  // request.setContent(new ByteArrayInputStream(payload));
-  // request.addHeader("Content-Length", String.valueOf(payload.length));
-  // request.addHeader("Content-Type", "application/json");
-
-  //     }
-
-  //     config.getSigner().sign(request, config.getCredentials());
-  //     try {
-  //       Response<String> response =
-  //           client
-  //               .requestExecutionBuilder()
-  //               .errorResponseHandler(new ErrorResponseHandler())
-  //               .request(request)
-  //               .execute(new StringResponseHandler());
-  //       int statusCode = response.getHttpResponse().getStatusCode();
-  //       String messageBody = response.getAwsResponse();
-  //       if (statusCode / 100 * 100 == 200) {
-  //         if (responseType == String.class) {
-  //           @SuppressWarnings("unchecked")
-  //           R responseObject = (R) messageBody;
-  //           return new VinylDNSSuccessResponse<>(responseObject, messageBody, statusCode);
-  //         }
-  //         R responseObject = gson.fromJson(messageBody, responseType);
-  //         return new VinylDNSSuccessResponse<>(responseObject, messageBody, statusCode);
-  //       } else {
-  //         return new VinylDNSFailureResponse<>(messageBody, statusCode);
-  //       }
-  //     } catch (AmazonServiceException e) {
-  //       return new VinylDNSFailureResponse<>(e.getRawResponseContent(), e.getStatusCode());
-  //     }
-  //   }
-
   private String getBaseUrl() {
     if (config.getBaseUrl().endsWith("/")) {
       return config.getBaseUrl();

--- a/src/main/java/io/vinyldns/java/VinylDNSClientImpl.java
+++ b/src/main/java/io/vinyldns/java/VinylDNSClientImpl.java
@@ -59,6 +59,8 @@ public class VinylDNSClientImpl implements VinylDNSClient {
 
   private AmazonHttpClient client;
 
+  private final CloseableHttpClient httpClient;
+
   private static final class HttpDeleteWithBody extends HttpEntityEnclosingRequestBase {
     public static final String METHOD_NAME = "DELETE";
 
@@ -82,8 +84,8 @@ public class VinylDNSClientImpl implements VinylDNSClient {
 
   public VinylDNSClientImpl(VinylDNSClientConfig config) {
     this.config = config;
-
     this.client = new AmazonHttpClient(new ClientConfiguration());
+    this.httpClient = HttpClients.custom().disableContentCompression().build();
   }
 
   public VinylDNSClientImpl() {
@@ -96,6 +98,7 @@ public class VinylDNSClientImpl implements VinylDNSClient {
             SignerFactory.getSigner("VinylDNS", "us/east"));
 
     this.client = new AmazonHttpClient(new ClientConfiguration());
+    this.httpClient = HttpClients.custom().disableContentCompression().build();
   }
 
   // Zone
@@ -710,7 +713,7 @@ public class VinylDNSClientImpl implements VinylDNSClient {
     VinylDNSResponse<GetRecordSetResponse> rsResponse =
         getRecordSet(new GetRecordSetRequest(payload.getZoneId(), payload.getRecordSetId()));
     if (!(rsResponse instanceof VinylDNSSuccessResponse)) {
-      throw new RuntimeException("Failed to fetch RecordSet before transfer");
+      return new VinylDNSFailureResponse<>(rsResponse.getMessageBody(), rsResponse.getStatusCode());
     }
     RecordSet rs = rsResponse.getValue().getRecordSet();
     RecordSetTransferPayload body =
@@ -824,9 +827,7 @@ public class VinylDNSClientImpl implements VinylDNSClient {
 
       http.setEntity(new ByteArrayEntity(payloadBytes, ContentType.APPLICATION_JSON));
 
-      try (CloseableHttpClient httpClient =
-              HttpClients.custom().disableContentCompression().build();
-          CloseableHttpResponse resp = httpClient.execute(http)) {
+      try (CloseableHttpResponse resp = httpClient.execute(http)) {
 
         int statusCode = resp.getStatusLine().getStatusCode();
         String messageBody =

--- a/src/main/java/io/vinyldns/java/model/acl/ACLRule.java
+++ b/src/main/java/io/vinyldns/java/model/acl/ACLRule.java
@@ -1,51 +1,58 @@
-/**
+/*
  * Copyright 2018 Comcast Cable Communications Management, LLC
  *
- * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
- * except in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * <p>Unless required by applicable law or agreed to in writing, software distributed under the
- * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing permissions and
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.vinyldns.java.model.acl;
 
 import io.vinyldns.java.model.record.RecordType;
+import java.util.Objects;
 import java.util.Set;
 
 public class ACLRule {
-  private AccessLevel accessLevel;
-  private String description; // optional
+  private ZoneAccessLevel accessLevel;
+  private String description;
+  private String displayName;
   private String userId; // optional
   private String groupId; // optional
-  private String recordMask; // optional
+  private String recordMask;
   private Set<RecordType> recordTypes;
 
   public ACLRule() {}
 
   public ACLRule(
-      AccessLevel accessLevel,
+      ZoneAccessLevel accessLevel,
       String description,
+      String displayName,
       String userId,
       String groupId,
       String recordMask,
       Set<RecordType> recordTypes) {
     this.accessLevel = accessLevel;
     this.description = description;
+    this.displayName = displayName;
     this.userId = userId;
     this.groupId = groupId;
     this.recordMask = recordMask;
     this.recordTypes = recordTypes;
   }
 
-  public AccessLevel getAccessLevel() {
+  public ZoneAccessLevel getAccessLevel() {
     return accessLevel;
   }
 
-  public void setAccessLevel(AccessLevel accessLevel) {
+  public void setAccessLevel(ZoneAccessLevel accessLevel) {
     this.accessLevel = accessLevel;
   }
 
@@ -55,6 +62,14 @@ public class ACLRule {
 
   public void setDescription(String description) {
     this.description = description;
+  }
+
+  public String getDisplayName() {
+    return displayName;
+  }
+
+  public void setDisplayName(String displayName) {
+    this.displayName = displayName;
   }
 
   public String getUserId() {
@@ -97,6 +112,9 @@ public class ACLRule {
         + ", description='"
         + description
         + '\''
+        + ", displayName='"
+        + displayName
+        + '\''
         + ", userId='"
         + userId
         + '\''
@@ -114,29 +132,20 @@ public class ACLRule {
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
-
+    if (!(o instanceof ACLRule)) return false;
     ACLRule aclRule = (ACLRule) o;
-
-    if (accessLevel != aclRule.accessLevel) return false;
-    if (description != null
-        ? !description.equals(aclRule.description)
-        : aclRule.description != null) return false;
-    if (userId != null ? !userId.equals(aclRule.userId) : aclRule.userId != null) return false;
-    if (groupId != null ? !groupId.equals(aclRule.groupId) : aclRule.groupId != null) return false;
-    if (recordMask != null ? !recordMask.equals(aclRule.recordMask) : aclRule.recordMask != null)
-      return false;
-    return recordTypes.equals(aclRule.recordTypes);
+    return accessLevel == aclRule.accessLevel
+        && Objects.equals(description, aclRule.description)
+        && Objects.equals(displayName, aclRule.displayName)
+        && Objects.equals(userId, aclRule.userId)
+        && Objects.equals(groupId, aclRule.groupId)
+        && Objects.equals(recordMask, aclRule.recordMask)
+        && Objects.equals(recordTypes, aclRule.recordTypes);
   }
 
   @Override
   public int hashCode() {
-    int result = accessLevel.hashCode();
-    result = 31 * result + (description != null ? description.hashCode() : 0);
-    result = 31 * result + (userId != null ? userId.hashCode() : 0);
-    result = 31 * result + (groupId != null ? groupId.hashCode() : 0);
-    result = 31 * result + (recordMask != null ? recordMask.hashCode() : 0);
-    result = 31 * result + recordTypes.hashCode();
-    return result;
+    return Objects.hash(
+        accessLevel, description, displayName, userId, groupId, recordMask, recordTypes);
   }
 }

--- a/src/main/java/io/vinyldns/java/model/acl/ZoneAccessLevel.java
+++ b/src/main/java/io/vinyldns/java/model/acl/ZoneAccessLevel.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.vinyldns.java.model.acl;
+
+public enum ZoneAccessLevel {
+  NoAccess,
+  Read,
+  Write,
+  Delete
+}

--- a/src/main/java/io/vinyldns/java/model/health/GetStatusRequest.java
+++ b/src/main/java/io/vinyldns/java/model/health/GetStatusRequest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.vinyldns.java.model.health;
+
+import java.util.Objects;
+
+/** Request object for GET /status (no parameters) */
+public class GetStatusRequest {
+  public GetStatusRequest() {}
+
+  @Override
+  public String toString() {
+    return "GetStatusRequest{}";
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    return o instanceof GetStatusRequest;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash("GetStatusRequest");
+  }
+}

--- a/src/main/java/io/vinyldns/java/model/health/StatusResponse.java
+++ b/src/main/java/io/vinyldns/java/model/health/StatusResponse.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.vinyldns.java.model.health;
+
+import java.time.Instant;
+import java.util.Objects;
+
+/** Response object for GET /status and POST /status */
+public class StatusResponse {
+  private final boolean processingEnabled;
+  private final Instant lastUpdated;
+  private final String message;
+
+  public StatusResponse(boolean processingEnabled, Instant lastUpdated, String message) {
+    this.processingEnabled = processingEnabled;
+    this.lastUpdated = lastUpdated;
+    this.message = message;
+  }
+
+  public boolean isProcessingEnabled() {
+    return processingEnabled;
+  }
+
+  public Instant getLastUpdated() {
+    return lastUpdated;
+  }
+
+  public String getMessage() {
+    return message;
+  }
+
+  @Override
+  public String toString() {
+    return "StatusResponse{"
+        + "processingEnabled="
+        + processingEnabled
+        + ", lastUpdated="
+        + lastUpdated
+        + ", message='"
+        + message
+        + '\''
+        + '}';
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (!(o instanceof StatusResponse)) return false;
+    StatusResponse that = (StatusResponse) o;
+    return processingEnabled == that.processingEnabled
+        && Objects.equals(lastUpdated, that.lastUpdated)
+        && Objects.equals(message, that.message);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(processingEnabled, lastUpdated, message);
+  }
+}

--- a/src/main/java/io/vinyldns/java/model/health/UpdateStatusRequest.java
+++ b/src/main/java/io/vinyldns/java/model/health/UpdateStatusRequest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.vinyldns.java.model.health;
+
+import java.util.Objects;
+
+/** Request object for POST /status (enable/disable processing) */
+public class UpdateStatusRequest {
+  private final boolean processingEnabled;
+  private final String message;
+
+  public UpdateStatusRequest(boolean processingEnabled, String message) {
+    this.processingEnabled = processingEnabled;
+    this.message = message;
+  }
+
+  public boolean isProcessingEnabled() {
+    return processingEnabled;
+  }
+
+  public String getMessage() {
+    return message;
+  }
+
+  @Override
+  public String toString() {
+    return "UpdateStatusRequest{"
+        + "processingEnabled="
+        + processingEnabled
+        + ", message='"
+        + message
+        + '\''
+        + '}';
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (!(o instanceof UpdateStatusRequest)) return false;
+    UpdateStatusRequest that = (UpdateStatusRequest) o;
+    return processingEnabled == that.processingEnabled && Objects.equals(message, that.message);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(processingEnabled, message);
+  }
+}

--- a/src/main/java/io/vinyldns/java/model/membership/GetGroupChangeRequest.java
+++ b/src/main/java/io/vinyldns/java/model/membership/GetGroupChangeRequest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.vinyldns.java.model.membership;
+
+/** Request object for GET /groups/change/{groupChangeId} */
+public class GetGroupChangeRequest {
+  private final String groupChangeId;
+
+  public GetGroupChangeRequest(String groupChangeId) {
+    this.groupChangeId = groupChangeId;
+  }
+
+  public String getGroupChangeId() {
+    return groupChangeId;
+  }
+
+  @Override
+  public String toString() {
+    return "GetGroupChangeRequest{" + "groupChangeId='" + groupChangeId + '\'' + '}';
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (!(o instanceof GetGroupChangeRequest)) return false;
+    GetGroupChangeRequest that = (GetGroupChangeRequest) o;
+    return groupChangeId.equals(that.groupChangeId);
+  }
+
+  @Override
+  public int hashCode() {
+    return groupChangeId.hashCode();
+  }
+}

--- a/src/main/java/io/vinyldns/java/model/membership/GetGroupChangeResponse.java
+++ b/src/main/java/io/vinyldns/java/model/membership/GetGroupChangeResponse.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.vinyldns.java.model.membership;
+
+/** Response object for GET /groups/change/{groupChangeId} */
+public class GetGroupChangeResponse {
+  private final GroupChange groupChange;
+
+  public GetGroupChangeResponse(GroupChange groupChange) {
+    this.groupChange = groupChange;
+  }
+
+  public GroupChange getGroupChange() {
+    return groupChange;
+  }
+
+  @Override
+  public String toString() {
+    return "GetGroupChangeResponse{" + "groupChange=" + groupChange + '}';
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (!(o instanceof GetGroupChangeResponse)) return false;
+    GetGroupChangeResponse that = (GetGroupChangeResponse) o;
+    return groupChange.equals(that.groupChange);
+  }
+
+  @Override
+  public int hashCode() {
+    return groupChange.hashCode();
+  }
+}

--- a/src/main/java/io/vinyldns/java/model/membership/GetUserRequest.java
+++ b/src/main/java/io/vinyldns/java/model/membership/GetUserRequest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.vinyldns.java.model.membership;
+
+/** Request object for GET /users/{userId} */
+public class GetUserRequest {
+  private final String userId;
+
+  public GetUserRequest(String userId) {
+    this.userId = userId;
+  }
+
+  public String getUserId() {
+    return userId;
+  }
+
+  @Override
+  public String toString() {
+    return "GetUserRequest{" + "userId='" + userId + '\'' + '}';
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (!(o instanceof GetUserRequest)) return false;
+    GetUserRequest that = (GetUserRequest) o;
+    return userId.equals(that.userId);
+  }
+
+  @Override
+  public int hashCode() {
+    return userId.hashCode();
+  }
+}

--- a/src/main/java/io/vinyldns/java/model/membership/GetUserResponse.java
+++ b/src/main/java/io/vinyldns/java/model/membership/GetUserResponse.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.vinyldns.java.model.membership;
+
+/** Response object for GET /users/{userId} */
+public class GetUserResponse {
+  private final UserInfo user;
+
+  public GetUserResponse(UserInfo user) {
+    this.user = user;
+  }
+
+  public UserInfo getUser() {
+    return user;
+  }
+
+  @Override
+  public String toString() {
+    return "GetUserResponse{" + "user=" + user + '}';
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (!(o instanceof GetUserResponse)) return false;
+    GetUserResponse that = (GetUserResponse) o;
+    return user.equals(that.user);
+  }
+
+  @Override
+  public int hashCode() {
+    return user.hashCode();
+  }
+}

--- a/src/main/java/io/vinyldns/java/model/membership/LockUnlockUserResponse.java
+++ b/src/main/java/io/vinyldns/java/model/membership/LockUnlockUserResponse.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.vinyldns.java.model.membership;
+
+/** Response object for lock/unlock user operations */
+public class LockUnlockUserResponse {
+  private final UserInfo user;
+
+  public LockUnlockUserResponse(UserInfo user) {
+    this.user = user;
+  }
+
+  public UserInfo getUser() {
+    return user;
+  }
+
+  @Override
+  public String toString() {
+    return "LockUnlockUserResponse{" + "user=" + user + '}';
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (!(o instanceof LockUnlockUserResponse)) return false;
+    LockUnlockUserResponse that = (LockUnlockUserResponse) o;
+    return user.equals(that.user);
+  }
+
+  @Override
+  public int hashCode() {
+    return user.hashCode();
+  }
+}

--- a/src/main/java/io/vinyldns/java/model/membership/LockUserRequest.java
+++ b/src/main/java/io/vinyldns/java/model/membership/LockUserRequest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.vinyldns.java.model.membership;
+
+/** Request object for PUT /users/{userId}/lock */
+public class LockUserRequest {
+  private final String userId;
+
+  public LockUserRequest(String userId) {
+    this.userId = userId;
+  }
+
+  public String getUserId() {
+    return userId;
+  }
+
+  @Override
+  public String toString() {
+    return "LockUserRequest{" + "userId='" + userId + '\'' + '}';
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (!(o instanceof LockUserRequest)) return false;
+    LockUserRequest that = (LockUserRequest) o;
+    return userId.equals(that.userId);
+  }
+
+  @Override
+  public int hashCode() {
+    return userId.hashCode();
+  }
+}

--- a/src/main/java/io/vinyldns/java/model/membership/UnlockUserRequest.java
+++ b/src/main/java/io/vinyldns/java/model/membership/UnlockUserRequest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.vinyldns.java.model.membership;
+
+/** Request object for PUT /users/{userId}/unlock */
+public class UnlockUserRequest {
+  private final String userId;
+
+  public UnlockUserRequest(String userId) {
+    this.userId = userId;
+  }
+
+  public String getUserId() {
+    return userId;
+  }
+
+  @Override
+  public String toString() {
+    return "UnlockUserRequest{" + "userId='" + userId + '\'' + '}';
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (!(o instanceof UnlockUserRequest)) return false;
+    UnlockUserRequest that = (UnlockUserRequest) o;
+    return userId.equals(that.userId);
+  }
+
+  @Override
+  public int hashCode() {
+    return userId.hashCode();
+  }
+}

--- a/src/main/java/io/vinyldns/java/model/record/set/GetFailedRecordSetChangesRequest.java
+++ b/src/main/java/io/vinyldns/java/model/record/set/GetFailedRecordSetChangesRequest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the License governing permissions and limitations under the License.
+ */
+package io.vinyldns.java.model.record.set;
+
+/** Request object for GET /metrics/health/zones/{zoneId}/recordsetchangesfailure */
+public class GetFailedRecordSetChangesRequest {
+
+  private final String zoneId;
+
+  public GetFailedRecordSetChangesRequest(String zoneId) {
+    this.zoneId = zoneId;
+  }
+
+  public String getZoneId() {
+    return zoneId;
+  }
+
+  @Override
+  public String toString() {
+    return "GetFailedRecordSetChangesRequest{" + "zoneId='" + zoneId + '\'' + '}';
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (!(o instanceof GetFailedRecordSetChangesRequest)) return false;
+    GetFailedRecordSetChangesRequest that = (GetFailedRecordSetChangesRequest) o;
+    return zoneId.equals(that.zoneId);
+  }
+
+  @Override
+  public int hashCode() {
+    return zoneId.hashCode();
+  }
+}

--- a/src/main/java/io/vinyldns/java/model/record/set/GetFailedRecordSetChangesResponse.java
+++ b/src/main/java/io/vinyldns/java/model/record/set/GetFailedRecordSetChangesResponse.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.vinyldns.java.model.record.set;
+
+public class GetFailedRecordSetChangesResponse {
+  private final int failureCount;
+
+  public GetFailedRecordSetChangesResponse(int failureCount) {
+    this.failureCount = failureCount;
+  }
+
+  public int getFailureCount() {
+    return failureCount;
+  }
+
+  @Override
+  public String toString() {
+    return "GetFailedRecordSetChangesResponse{" + "failureCount=" + failureCount + '}';
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (!(o instanceof GetFailedRecordSetChangesResponse)) return false;
+    GetFailedRecordSetChangesResponse that = (GetFailedRecordSetChangesResponse) o;
+    return failureCount == that.failureCount;
+  }
+
+  @Override
+  public int hashCode() {
+    return Integer.hashCode(failureCount);
+  }
+}

--- a/src/main/java/io/vinyldns/java/model/record/set/GetRecordSetChangeHistoryRequest.java
+++ b/src/main/java/io/vinyldns/java/model/record/set/GetRecordSetChangeHistoryRequest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.vinyldns.java.model.record.set;
+
+/**
+ * Request filter for GET /recordsetchange/history.
+ *
+ * <p>Encapsulates query parameters for retrieving record set change history.
+ *
+ * @since 1.0
+ */
+public class GetRecordSetChangeHistoryRequest {
+  private final String zoneId;
+  private final String fqdn;
+  private final String recordType;
+  private final String startFrom; // nullable
+  private final Integer maxItems; // nullable
+
+  /**
+   * Creates a request to query record set change history.
+   *
+   * @param zoneId the zone identifier
+   * @param fqdn the fully qualified domain name
+   * @param recordType the record type (e.g., A, AAAA, CNAME)
+   * @param startFrom an opaque pagination token to start from (nullable)
+   * @param maxItems the maximum number of items to return (nullable)
+   */
+  public GetRecordSetChangeHistoryRequest(
+      String zoneId, String fqdn, String recordType, String startFrom, Integer maxItems) {
+    this.zoneId = zoneId;
+    this.fqdn = fqdn;
+    this.recordType = recordType;
+    this.startFrom = startFrom;
+    this.maxItems = maxItems;
+  }
+
+  /** @return the zone identifier */
+  public String getZoneId() {
+    return zoneId;
+  }
+
+  /** @return the fully qualified domain name */
+  public String getFqdn() {
+    return fqdn;
+  }
+
+  /** @return the record type */
+  public String getRecordType() {
+    return recordType;
+  }
+
+  /** @return the pagination token to start from (nullable) */
+  public String getStartFrom() {
+    return startFrom;
+  }
+
+  /** @return the maximum number of items to return (nullable) */
+  public Integer getMaxItems() {
+    return maxItems;
+  }
+
+  @Override
+  public String toString() {
+    return "GetRecordSetChangeHistoryRequest{"
+        + "zoneId='"
+        + zoneId
+        + '\''
+        + ", fqdn='"
+        + fqdn
+        + '\''
+        + ", recordType='"
+        + recordType
+        + '\''
+        + ", startFrom='"
+        + startFrom
+        + '\''
+        + ", maxItems="
+        + maxItems
+        + '}';
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (!(o instanceof GetRecordSetChangeHistoryRequest)) return false;
+    GetRecordSetChangeHistoryRequest that = (GetRecordSetChangeHistoryRequest) o;
+    return zoneId.equals(that.zoneId)
+        && fqdn.equals(that.fqdn)
+        && recordType.equals(that.recordType)
+        && ((startFrom == null && that.startFrom == null)
+            || (startFrom != null && startFrom.equals(that.startFrom)))
+        && ((maxItems == null && that.maxItems == null)
+            || (maxItems != null && maxItems.equals(that.maxItems)));
+  }
+
+  @Override
+  public int hashCode() {
+    int result = zoneId.hashCode();
+    result = 31 * result + fqdn.hashCode();
+    result = 31 * result + recordType.hashCode();
+    result = 31 * result + (startFrom != null ? startFrom.hashCode() : 0);
+    result = 31 * result + (maxItems != null ? maxItems.hashCode() : 0);
+    return result;
+  }
+}

--- a/src/main/java/io/vinyldns/java/model/record/set/GetRecordSetChangeHistoryResponse.java
+++ b/src/main/java/io/vinyldns/java/model/record/set/GetRecordSetChangeHistoryResponse.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.vinyldns.java.model.record.set;
+
+import java.util.List;
+
+public class GetRecordSetChangeHistoryResponse {
+  private final List<RecordSetChange> changes;
+
+  public GetRecordSetChangeHistoryResponse(List<RecordSetChange> changes) {
+    this.changes = changes;
+  }
+
+  public List<RecordSetChange> getChanges() {
+    return changes;
+  }
+
+  @Override
+  public String toString() {
+    return "GetRecordSetChangeHistoryResponse{" + "changes=" + changes + '}';
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (!(o instanceof GetRecordSetChangeHistoryResponse)) return false;
+    GetRecordSetChangeHistoryResponse that = (GetRecordSetChangeHistoryResponse) o;
+    return changes.equals(that.changes);
+  }
+
+  @Override
+  public int hashCode() {
+    return changes.hashCode();
+  }
+}

--- a/src/main/java/io/vinyldns/java/model/record/set/GetRecordSetCountRequest.java
+++ b/src/main/java/io/vinyldns/java/model/record/set/GetRecordSetCountRequest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.vinyldns.java.model.record.set;
+
+/** Request object for GET /zones/{zoneId}/recordsetcount */
+public class GetRecordSetCountRequest {
+  private final String zoneId;
+
+  public GetRecordSetCountRequest(String zoneId) {
+    this.zoneId = zoneId;
+  }
+
+  public String getZoneId() {
+    return zoneId;
+  }
+
+  @Override
+  public String toString() {
+    return "GetRecordSetCountRequest{" + "zoneId='" + zoneId + '\'' + '}';
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (!(o instanceof GetRecordSetCountRequest)) return false;
+    GetRecordSetCountRequest that = (GetRecordSetCountRequest) o;
+    return zoneId.equals(that.zoneId);
+  }
+
+  @Override
+  public int hashCode() {
+    return zoneId.hashCode();
+  }
+}

--- a/src/main/java/io/vinyldns/java/model/record/set/GetRecordSetCountResponse.java
+++ b/src/main/java/io/vinyldns/java/model/record/set/GetRecordSetCountResponse.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.vinyldns.java.model.record.set;
+
+/** Response object for GET /zones/{zoneId}/recordsetcount */
+public class GetRecordSetCountResponse {
+  private final int count;
+
+  public GetRecordSetCountResponse(int count) {
+    this.count = count;
+  }
+
+  public int getCount() {
+    return count;
+  }
+
+  @Override
+  public String toString() {
+    return "GetRecordSetCountResponse{" + "count=" + count + '}';
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (!(o instanceof GetRecordSetCountResponse)) return false;
+    GetRecordSetCountResponse that = (GetRecordSetCountResponse) o;
+    return count == that.count;
+  }
+
+  @Override
+  public int hashCode() {
+    return Integer.hashCode(count);
+  }
+}

--- a/src/main/java/io/vinyldns/java/model/record/set/OwnershipTransfer.java
+++ b/src/main/java/io/vinyldns/java/model/record/set/OwnershipTransfer.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.vinyldns.java.model.record.set;
+
+import java.util.Objects;
+
+/** Ownership transfer data included in the PUT request body as "recordSetGroupChange". */
+public class OwnershipTransfer {
+  private final OwnershipTransferStatus ownershipTransferStatus;
+  private final String requestedOwnerGroupId;
+
+  public OwnershipTransfer(
+      OwnershipTransferStatus ownershipTransferStatus, String requestedOwnerGroupId) {
+    this.ownershipTransferStatus =
+        Objects.requireNonNull(ownershipTransferStatus, "ownershipTransferStatus");
+    this.requestedOwnerGroupId = requestedOwnerGroupId;
+  }
+
+  public OwnershipTransferStatus getOwnershipTransferStatus() {
+    return ownershipTransferStatus;
+  }
+
+  public String getRequestedOwnerGroupId() {
+    return requestedOwnerGroupId;
+  }
+
+  @Override
+  public String toString() {
+    return "OwnershipTransfer{"
+        + "ownershipTransferStatus="
+        + ownershipTransferStatus
+        + ", requestedOwnerGroupId='"
+        + requestedOwnerGroupId
+        + '\''
+        + '}';
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (!(o instanceof OwnershipTransfer)) return false;
+    OwnershipTransfer that = (OwnershipTransfer) o;
+    return ownershipTransferStatus == that.ownershipTransferStatus
+        && Objects.equals(requestedOwnerGroupId, that.requestedOwnerGroupId);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(ownershipTransferStatus, requestedOwnerGroupId);
+  }
+}

--- a/src/main/java/io/vinyldns/java/model/record/set/OwnershipTransferStatus.java
+++ b/src/main/java/io/vinyldns/java/model/record/set/OwnershipTransferStatus.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.vinyldns.java.model.record.set;
+
+public enum OwnershipTransferStatus {
+  AutoApproved,
+  Cancelled,
+  ManuallyApproved,
+  ManuallyRejected,
+  Requested,
+  PendingReview
+}

--- a/src/main/java/io/vinyldns/java/model/record/set/RecordSetOwnershipTransferRequest.java
+++ b/src/main/java/io/vinyldns/java/model/record/set/RecordSetOwnershipTransferRequest.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.vinyldns.java.model.record.set;
+
+import java.util.Objects;
+
+/**
+ * Request object for PUT /zones/{zoneId}/recordsets/{recordSetId} to perform ownership transfer
+ * actions. The body includes ownerGroupId changes (when approving) and recordSetGroupChange
+ * payload.
+ */
+public class RecordSetOwnershipTransferRequest {
+  private final String zoneId;
+  private final String recordSetId;
+  private final String currentOwnerGroupId;
+  private final String requestedOwnerGroupId;
+  private final OwnershipTransferStatus status;
+  private final boolean updateOwnerGroup;
+
+  private final OwnershipTransfer recordSetGroupChange;
+
+  private RecordSetOwnershipTransferRequest(
+      String zoneId,
+      String recordSetId,
+      String currentOwnerGroupId,
+      String requestedOwnerGroupId,
+      OwnershipTransferStatus status,
+      boolean updateOwnerGroup,
+      OwnershipTransfer recordSetGroupChange) {
+    this.zoneId = zoneId;
+    this.recordSetId = recordSetId;
+    this.currentOwnerGroupId = currentOwnerGroupId;
+    this.requestedOwnerGroupId = requestedOwnerGroupId;
+    this.status = status;
+    this.updateOwnerGroup = updateOwnerGroup;
+    this.recordSetGroupChange = recordSetGroupChange;
+  }
+
+  public static RecordSetOwnershipTransferRequest of(
+      String zoneId, String recordSetId, String currentOwnerGroupId, String requestedOwnerGroupId) {
+    Objects.requireNonNull(zoneId, "zoneId is required");
+    Objects.requireNonNull(recordSetId, "recordSetId is required");
+    return new RecordSetOwnershipTransferRequest(
+        zoneId,
+        recordSetId,
+        currentOwnerGroupId,
+        requestedOwnerGroupId,
+        OwnershipTransferStatus.Requested,
+        false,
+        new OwnershipTransfer(OwnershipTransferStatus.Requested, requestedOwnerGroupId));
+  }
+
+  public RecordSetOwnershipTransferRequest withStatus(OwnershipTransferStatus status) {
+    Objects.requireNonNull(status, "status is required");
+    return new RecordSetOwnershipTransferRequest(
+        zoneId,
+        recordSetId,
+        currentOwnerGroupId,
+        requestedOwnerGroupId,
+        status,
+        updateOwnerGroup,
+        new OwnershipTransfer(status, requestedOwnerGroupId));
+  }
+
+  public RecordSetOwnershipTransferRequest withUpdateOwnerGroup(boolean update) {
+    return new RecordSetOwnershipTransferRequest(
+        zoneId,
+        recordSetId,
+        currentOwnerGroupId,
+        requestedOwnerGroupId,
+        status,
+        update,
+        recordSetGroupChange);
+  }
+
+  // --- Getters ---
+
+  public String getZoneId() {
+    return zoneId;
+  }
+
+  public String getRecordSetId() {
+    return recordSetId;
+  }
+
+  public String getCurrentOwnerGroupId() {
+    return currentOwnerGroupId;
+  }
+
+  public String getRequestedOwnerGroupId() {
+    return requestedOwnerGroupId;
+  }
+
+  public OwnershipTransferStatus getStatus() {
+    return status;
+  }
+
+  public boolean isUpdateOwnerGroup() {
+    return updateOwnerGroup;
+  }
+
+  /**
+   * The API expects the record set body to include { "ownerGroupId": "...", "recordSetGroupChange":
+   * {...} } If updateOwnerGroup is true (approval), the service implementation should set the
+   * ownerGroupId to requestedOwnerGroupId.
+   */
+  public OwnershipTransfer getRecordSetGroupChange() {
+    return recordSetGroupChange;
+  }
+
+  @Override
+  public String toString() {
+    return "RecordSetOwnershipTransferRequest{"
+        + "zoneId='"
+        + zoneId
+        + '\''
+        + ", recordSetId='"
+        + recordSetId
+        + '\''
+        + ", currentOwnerGroupId='"
+        + currentOwnerGroupId
+        + '\''
+        + ", requestedOwnerGroupId='"
+        + requestedOwnerGroupId
+        + '\''
+        + ", status="
+        + status
+        + ", updateOwnerGroup="
+        + updateOwnerGroup
+        + ", recordSetGroupChange="
+        + recordSetGroupChange
+        + '}';
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (!(o instanceof RecordSetOwnershipTransferRequest)) return false;
+    RecordSetOwnershipTransferRequest that = (RecordSetOwnershipTransferRequest) o;
+    return updateOwnerGroup == that.updateOwnerGroup
+        && Objects.equals(zoneId, that.zoneId)
+        && Objects.equals(recordSetId, that.recordSetId)
+        && Objects.equals(currentOwnerGroupId, that.currentOwnerGroupId)
+        && Objects.equals(requestedOwnerGroupId, that.requestedOwnerGroupId)
+        && status == that.status
+        && Objects.equals(recordSetGroupChange, that.recordSetGroupChange);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        zoneId,
+        recordSetId,
+        currentOwnerGroupId,
+        requestedOwnerGroupId,
+        status,
+        updateOwnerGroup,
+        recordSetGroupChange);
+  }
+}

--- a/src/main/java/io/vinyldns/java/model/record/set/RecordSetTransferPayload.java
+++ b/src/main/java/io/vinyldns/java/model/record/set/RecordSetTransferPayload.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.vinyldns.java.model.record.set;
+
+public class RecordSetTransferPayload extends RecordSet {
+
+  private final OwnershipTransfer recordSetGroupChange;
+
+  public RecordSetTransferPayload(
+      RecordSet base,
+      OwnershipTransfer recordSetGroupChange,
+      boolean updateOwnerGroup,
+      String requestedOwnerGroupId) {
+
+    super(
+        base.getZoneId(),
+        base.getName(),
+        base.getType(),
+        base.getTtl(),
+        base.getRecords(),
+        base.getId(),
+        updateOwnerGroup ? requestedOwnerGroupId : base.getOwnerGroupId(),
+        base.getStatus(),
+        base.getCreated(),
+        base.getUpdated());
+
+    this.recordSetGroupChange = recordSetGroupChange;
+  }
+
+  public OwnershipTransfer getRecordSetGroupChange() {
+    return recordSetGroupChange;
+  }
+}

--- a/src/main/java/io/vinyldns/java/model/record/set/RecordSetUpdateResponse.java
+++ b/src/main/java/io/vinyldns/java/model/record/set/RecordSetUpdateResponse.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.vinyldns.java.model.record.set;
+
+import java.util.Objects;
+
+/** Response object for PUT /zones/{zoneId}/recordsets/{recordSetId}. */
+public class RecordSetUpdateResponse {
+  private final String recordSetId;
+  private final String zoneId;
+  private final String ownerGroupId;
+  private final OwnershipTransferStatus ownershipTransferStatus;
+  private final String message;
+
+  public RecordSetUpdateResponse(
+      String recordSetId,
+      String zoneId,
+      String ownerGroupId,
+      OwnershipTransferStatus ownershipTransferStatus,
+      String message) {
+    this.recordSetId = recordSetId;
+    this.zoneId = zoneId;
+    this.ownerGroupId = ownerGroupId;
+    this.ownershipTransferStatus = ownershipTransferStatus;
+    this.message = message;
+  }
+
+  public String getRecordSetId() {
+    return recordSetId;
+  }
+
+  public String getZoneId() {
+    return zoneId;
+  }
+
+  public String getOwnerGroupId() {
+    return ownerGroupId;
+  }
+
+  public OwnershipTransferStatus getOwnershipTransferStatus() {
+    return ownershipTransferStatus;
+  }
+
+  public String getMessage() {
+    return message;
+  }
+
+  @Override
+  public String toString() {
+    return "RecordSetUpdateResponse{"
+        + "recordSetId='"
+        + recordSetId
+        + '\''
+        + ", zoneId='"
+        + zoneId
+        + '\''
+        + ", ownerGroupId='"
+        + ownerGroupId
+        + '\''
+        + ", ownershipTransferStatus="
+        + ownershipTransferStatus
+        + ", message='"
+        + message
+        + '\''
+        + '}';
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (!(o instanceof RecordSetUpdateResponse)) return false;
+    RecordSetUpdateResponse that = (RecordSetUpdateResponse) o;
+    return Objects.equals(recordSetId, that.recordSetId)
+        && Objects.equals(zoneId, that.zoneId)
+        && Objects.equals(ownerGroupId, that.ownerGroupId)
+        && ownershipTransferStatus == that.ownershipTransferStatus
+        && Objects.equals(message, that.message);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(recordSetId, zoneId, ownerGroupId, ownershipTransferStatus, message);
+  }
+}

--- a/src/main/java/io/vinyldns/java/model/zone/AddZoneAclRuleRequest.java
+++ b/src/main/java/io/vinyldns/java/model/zone/AddZoneAclRuleRequest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.vinyldns.java.model.zone;
+
+import io.vinyldns.java.model.acl.ACLRule;
+import java.util.Objects;
+
+public class AddZoneAclRuleRequest {
+  private final String zoneId;
+  private final ACLRule rule;
+
+  /**
+   * Constructs a request to add an ACL rule to a zone.
+   *
+   * @param zoneId the target zone identifier
+   * @param rule the ACL rule to add
+   */
+  public AddZoneAclRuleRequest(String zoneId, ACLRule rule) {
+    this.zoneId = zoneId;
+    this.rule = rule;
+  }
+
+  /** Returns the zone identifier. */
+  public String getZoneId() {
+    return zoneId;
+  }
+
+  /** Returns the ACL rule to add. */
+  public ACLRule getRule() {
+    return rule;
+  }
+
+  @Override
+  public String toString() {
+    return "AddZoneAclRuleRequest{" + "zoneId='" + zoneId + '\'' + ", rule=" + rule + '}';
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (!(o instanceof AddZoneAclRuleRequest)) return false;
+    AddZoneAclRuleRequest that = (AddZoneAclRuleRequest) o;
+    return Objects.equals(zoneId, that.zoneId) && Objects.equals(rule, that.rule);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(zoneId, rule);
+  }
+}

--- a/src/main/java/io/vinyldns/java/model/zone/AddZoneAclRuleResponse.java
+++ b/src/main/java/io/vinyldns/java/model/zone/AddZoneAclRuleResponse.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.vinyldns.java.model.zone;
+
+import io.vinyldns.java.model.acl.ACLRule;
+import java.util.Objects;
+
+public class AddZoneAclRuleResponse {
+  private final ACLRule rule;
+
+  /**
+   * Constructs the response with the persisted ACL rule.
+   *
+   * @param rule the ACL rule returned by the server
+   */
+  public AddZoneAclRuleResponse(ACLRule rule) {
+    this.rule = rule;
+  }
+
+  /** Returns the persisted ACL rule. */
+  public ACLRule getRule() {
+    return rule;
+  }
+
+  @Override
+  public String toString() {
+    return "AddZoneAclRuleResponse{" + "rule=" + rule + '}';
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (!(o instanceof AddZoneAclRuleResponse)) return false;
+    AddZoneAclRuleResponse that = (AddZoneAclRuleResponse) o;
+    return Objects.equals(rule, that.rule);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(rule);
+  }
+}

--- a/src/main/java/io/vinyldns/java/model/zone/DeleteZoneAclRuleRequest.java
+++ b/src/main/java/io/vinyldns/java/model/zone/DeleteZoneAclRuleRequest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.vinyldns.java.model.zone;
+
+import io.vinyldns.java.model.acl.ACLRule;
+import java.util.Objects;
+
+public class DeleteZoneAclRuleRequest {
+  private final String zoneId;
+  private final ACLRule rule;
+
+  /**
+   * Constructs a request to delete an ACL rule from a zone.
+   *
+   * @param zoneId the target zone identifier
+   * @param rule the ACL rule to delete (must match the server's stored rule fields)
+   */
+  public DeleteZoneAclRuleRequest(String zoneId, ACLRule rule) {
+    this.zoneId = zoneId;
+    this.rule = rule;
+  }
+
+  /** Returns the zone identifier. */
+  public String getZoneId() {
+    return zoneId;
+  }
+
+  /** Returns the ACL rule to delete. */
+  public ACLRule getRule() {
+    return rule;
+  }
+
+  @Override
+  public String toString() {
+    return "DeleteZoneAclRuleRequest{" + "zoneId='" + zoneId + '\'' + ", rule=" + rule + '}';
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (!(o instanceof DeleteZoneAclRuleRequest)) return false;
+    DeleteZoneAclRuleRequest that = (DeleteZoneAclRuleRequest) o;
+    return Objects.equals(zoneId, that.zoneId) && Objects.equals(rule, that.rule);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(zoneId, rule);
+  }
+}

--- a/src/main/java/io/vinyldns/java/model/zone/DeleteZoneAclRuleResponse.java
+++ b/src/main/java/io/vinyldns/java/model/zone/DeleteZoneAclRuleResponse.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.vinyldns.java.model.zone;
+
+import io.vinyldns.java.model.acl.ACLRule;
+import java.util.Objects;
+
+public class DeleteZoneAclRuleResponse {
+  private final boolean deleted;
+  private final ACLRule rule;
+
+  /**
+   * Constructs the response.
+   *
+   * @param deleted whether the rule was successfully deleted
+   * @param rule the rule that was deleted (optional; include if server returns it)
+   */
+  public DeleteZoneAclRuleResponse(boolean deleted, ACLRule rule) {
+    this.deleted = deleted;
+    this.rule = rule;
+  }
+
+  /** Returns true if the rule was deleted. */
+  public boolean isDeleted() {
+    return deleted;
+  }
+
+  /** Returns the deleted rule, if the server returns it. May be null. */
+  public ACLRule getRule() {
+    return rule;
+  }
+
+  @Override
+  public String toString() {
+    return "DeleteZoneAclRuleResponse{" + "deleted=" + deleted + ", rule=" + rule + '}';
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (!(o instanceof DeleteZoneAclRuleResponse)) return false;
+    DeleteZoneAclRuleResponse that = (DeleteZoneAclRuleResponse) o;
+    return deleted == that.deleted && Objects.equals(rule, that.rule);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(deleted, rule);
+  }
+}

--- a/src/main/java/io/vinyldns/java/model/zone/GetFailedZoneChangesRequest.java
+++ b/src/main/java/io/vinyldns/java/model/zone/GetFailedZoneChangesRequest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.vinyldns.java.model.zone;
+
+import java.util.Objects;
+
+/** Request object for GET /metrics/health/zonechangesfailure (no parameters) */
+public class GetFailedZoneChangesRequest {
+  public GetFailedZoneChangesRequest() {}
+
+  @Override
+  public String toString() {
+    return "GetFailedZoneChangesRequest{}";
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    return o instanceof GetFailedZoneChangesRequest;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash("GetFailedZoneChangesRequest");
+  }
+}

--- a/src/main/java/io/vinyldns/java/model/zone/GetFailedZoneChangesResponse.java
+++ b/src/main/java/io/vinyldns/java/model/zone/GetFailedZoneChangesResponse.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.vinyldns.java.model.zone;
+
+/** Response object for GET /metrics/health/zonechangesfailure */
+public class GetFailedZoneChangesResponse {
+  private final int failureCount;
+
+  public GetFailedZoneChangesResponse(int failureCount) {
+    this.failureCount = failureCount;
+  }
+
+  public int getFailureCount() {
+    return failureCount;
+  }
+
+  @Override
+  public String toString() {
+    return "GetFailedZoneChangesResponse{" + "failureCount=" + failureCount + '}';
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (!(o instanceof GetFailedZoneChangesResponse)) return false;
+    GetFailedZoneChangesResponse that = (GetFailedZoneChangesResponse) o;
+    return failureCount == that.failureCount;
+  }
+
+  @Override
+  public int hashCode() {
+    return Integer.hashCode(failureCount);
+  }
+}

--- a/src/main/java/io/vinyldns/java/model/zone/GetZoneDetailsRequest.java
+++ b/src/main/java/io/vinyldns/java/model/zone/GetZoneDetailsRequest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.vinyldns.java.model.zone;
+
+import java.util.Objects;
+
+/** Request object for GET /zones/{zoneId}/details */
+public class GetZoneDetailsRequest {
+  private final String zoneId;
+
+  public GetZoneDetailsRequest(String zoneId) {
+    this.zoneId = zoneId;
+  }
+
+  public String getZoneId() {
+    return zoneId;
+  }
+
+  @Override
+  public String toString() {
+    return "GetZoneDetailsRequest{" + "zoneId='" + zoneId + '\'' + '}';
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (!(o instanceof GetZoneDetailsRequest)) return false;
+    GetZoneDetailsRequest that = (GetZoneDetailsRequest) o;
+    return Objects.equals(zoneId, that.zoneId);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(zoneId);
+  }
+}

--- a/src/main/java/io/vinyldns/java/model/zone/GetZoneDetailsResponse.java
+++ b/src/main/java/io/vinyldns/java/model/zone/GetZoneDetailsResponse.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.vinyldns.java.model.zone;
+
+import io.vinyldns.java.model.acl.ZoneAccessLevel;
+import java.util.Objects;
+
+/** Response object for GET /zones/{zoneId}/details */
+public class GetZoneDetailsResponse {
+  private final Zone zone;
+  private final ZoneAccessLevel accessLevel;
+
+  public GetZoneDetailsResponse(Zone zone, ZoneAccessLevel accessLevel) {
+    this.zone = zone;
+    this.accessLevel = accessLevel;
+  }
+
+  public Zone getZone() {
+    return zone;
+  }
+
+  public ZoneAccessLevel getAccessLevel() {
+    return accessLevel;
+  }
+
+  @Override
+  public String toString() {
+    return "GetZoneDetailsResponse{" + "zone=" + zone + ", accessLevel=" + accessLevel + '}';
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (!(o instanceof GetZoneDetailsResponse)) return false;
+    GetZoneDetailsResponse that = (GetZoneDetailsResponse) o;
+    return Objects.equals(zone, that.zone) && accessLevel == that.accessLevel;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(zone, accessLevel);
+  }
+}


### PR DESCRIPTION
- Added endpoint builders and query helpers for health/status, zones, record sets, groups and  users.
- Implemented client methods for monitoring, status management, backend IDs, deleted zones, ACL rule add/delete, record set metrics and history, group utilities, and user administration.
- Introduced ownership transfer helpers for record sets (request/approve/reject/cancel) that wrap record set update payloads.
- Added unit tests covering all new endpoints and client methods.
- Fix SigV4 signing for DELETE endpoint.