### PR TITLE
Fix transfer not-found test expectations

### DIFF
--- a/src/test/java/io/vinyldns/java/VinylDNSClientTest.java
+++ b/src/test/java/io/vinyldns/java/VinylDNSClientTest.java
@@ -2471,47 +2471,55 @@ public class VinylDNSClientTest {
   }
 
   @Test
-  public void requestTransfer_recordSetNotFound_throws() {
+  public void requestTransfer_recordSetNotFound_returnsFailure() {
     stubGetRecordSetNotFound();
     RecordSetOwnershipTransferRequest requestObj = baseTransferRequest();
 
-    RuntimeException ex =
-        expectThrows(RuntimeException.class, () -> client.requestTransfer(requestObj));
+    VinylDNSResponse<RecordSetUpdateResponse> resp = client.requestTransfer(requestObj);
 
-    assertEquals(ex.getMessage(), "Failed to fetch RecordSet before transfer");
+    assertTrue(resp instanceof ResponseMarker.Failure);
+    assertEquals(404, resp.getStatusCode());
+    assertEquals("RecordSet not found", resp.getMessageBody());
+    assertNull(resp.getValue());
   }
 
   @Test
-  public void approveTransfer_recordSetNotFound_throws() {
+  public void approveTransfer_recordSetNotFound_returnsFailure() {
     stubGetRecordSetNotFound();
     RecordSetOwnershipTransferRequest requestObj = baseTransferRequest();
 
-    RuntimeException ex =
-        expectThrows(RuntimeException.class, () -> client.approveTransfer(requestObj));
+    VinylDNSResponse<RecordSetUpdateResponse> resp = client.approveTransfer(requestObj);
 
-    assertEquals(ex.getMessage(), "Failed to fetch RecordSet before transfer");
+    assertTrue(resp instanceof ResponseMarker.Failure);
+    assertEquals(404, resp.getStatusCode());
+    assertEquals("RecordSet not found", resp.getMessageBody());
+    assertNull(resp.getValue());
   }
 
   @Test
-  public void rejectTransfer_recordSetNotFound_throws() {
+  public void rejectTransfer_recordSetNotFound_returnsFailure() {
     stubGetRecordSetNotFound();
     RecordSetOwnershipTransferRequest requestObj = baseTransferRequest();
 
-    RuntimeException ex =
-        expectThrows(RuntimeException.class, () -> client.rejectTransfer(requestObj));
+    VinylDNSResponse<RecordSetUpdateResponse> resp = client.rejectTransfer(requestObj);
 
-    assertEquals(ex.getMessage(), "Failed to fetch RecordSet before transfer");
+    assertTrue(resp instanceof ResponseMarker.Failure);
+    assertEquals(404, resp.getStatusCode());
+    assertEquals("RecordSet not found", resp.getMessageBody());
+    assertNull(resp.getValue());
   }
 
   @Test
-  public void cancelTransfer_recordSetNotFound_throws() {
+  public void cancelTransfer_recordSetNotFound_returnsFailure() {
     stubGetRecordSetNotFound();
     RecordSetOwnershipTransferRequest requestObj = baseTransferRequest();
 
-    RuntimeException ex =
-        expectThrows(RuntimeException.class, () -> client.cancelTransfer(requestObj));
+    VinylDNSResponse<RecordSetUpdateResponse> resp = client.cancelTransfer(requestObj);
 
-    assertEquals(ex.getMessage(), "Failed to fetch RecordSet before transfer");
+    assertTrue(resp instanceof ResponseMarker.Failure);
+    assertEquals(404, resp.getStatusCode());
+    assertEquals("RecordSet not found", resp.getMessageBody());
+    assertNull(resp.getValue());
   }
 
   @Test


### PR DESCRIPTION
## Summary
- align ownership transfer not-found tests with the client response contract
- assert failure response details instead of expecting thrown exceptions
- keep the fix limited to the new transfer coverage added in #104

## Why
The transfer methods fetch the record set first and return a failure response when that lookup returns a non-2xx status. The implementation does not throw on a 404, and that matches the rest of the client API behavior.

## Testing
- export JAVA_HOME=/Library/Java/JavaVirtualMachines/temurin-17.jdk/Contents/Home
- export PATH="$JAVA_HOME/bin:$PATH"
- mvn -Dlicense.skip=true -Dfmt.skip=true -Dtest=VinylDNSClientTest test